### PR TITLE
Set oauth scope for product to P9 and skipped tests pending TBCs

### DIFF
--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -75,8 +75,7 @@ apigee:
           - identity-service-mock-{{ ENV.name }}
 {% endif %}
         scopes:
-          - 'urn:nhsd:apim:app:level3:{{ SERVICE_NAME }}'
-          - 'urn:nhsd:apim:user-nhs-cis2:aal3:{{ SERVICE_NAME }}'
+          - 'urn:nhsd:apim:user-nhs-login:P9:{{ SERVICE_NAME }}'
     specs:
       - name: {{ NAME }}
         path: {{ SERVICE_NAME }}.json

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -73,20 +73,20 @@ def test_app_level0(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
     resp = requests.get(f"{nhsd_apim_proxy_url}", headers=nhsd_apim_auth_headers)
     assert resp.status_code == 401  # unauthorized
 
-
+@pytest.mark.skip(reason="TBC: Are we supporting Application level 3 access to the API?")
 @pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_app_level3(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
     resp = requests.get(f"{nhsd_apim_proxy_url}", headers=nhsd_apim_auth_headers)
     assert resp.status_code == 200
 
-
+@pytest.mark.skip(reason="Requires API key to be shared with proxy and decision on endpoint and user to use")
 @pytest.mark.nhsd_apim_authorization(
     {
-        "access": "healthcare_worker",
-        "level": "aal3",
-        "login_form": {"username": "656005750104"},
+        "access": "patient",
+        "level": "P9",
+        "login_form": {"username": "TBC"}
     }
 )
-def test_cis2_aal3(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_nhs_login_p9(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
     resp = requests.get(f"{nhsd_apim_proxy_url}", headers=nhsd_apim_auth_headers)
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
* Routine Change

This change sets the API Product to only allow access to clients where end users have authenticated as NHS Login P9.
It also skips tests which we are not in a position to run yet as they need the API key for the target server to be shared with proxy and a decision about which path on the target server to hit and with which NHS number.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
