### PR TITLE
NPA-2051: Added policies to add User Auth Level and NHS Number

### DIFF
--- a/proxies/live/apiproxy/policies/AssignMessage.AddUserAuthLevel.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddUserAuthLevel.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage async="false" continueOnError="false" enabled="true" name="AddUserAuthLevel">
+    <DisplayName>Add User Auth Level</DisplayName>
+    <Add>
+        <Headers>
+            <Header name="accesstoken.auth_level">{accesstoken.auth_level}</Header>
+        </Headers>
+    </Add>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    <AssignTo createNew="false" transport="http" type="request"/>
+</AssignMessage>

--- a/proxies/live/apiproxy/policies/AssignMessage.AddUserNHSNumber.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddUserNHSNumber.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage async="false" continueOnError="false" enabled="true" name="AddUserNHSNumber">
+    <DisplayName>Add User NHS Number</DisplayName>
+    <Add>
+        <Headers>
+            <Header name="accesstoken.auth_user_id">{accesstoken.auth_user_id}</Header>
+        </Headers>
+    </Add>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    <AssignTo createNew="false" transport="http" type="request"/>
+</AssignMessage>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -10,6 +10,12 @@
       <Step>
         <Name>AddProxyURL</Name>
       </Step>
+      <Step>
+        <Name>AddUserAuthLevel</Name>
+      </Step>
+      <Step>
+        <Name>AddUserNHSNumber</Name>
+      </Step>
     </Request>
   </PreFlow>
   <FaultRules>


### PR DESCRIPTION
## Summary
* Routine Change

The VRS target server(s) expect the end user's NHS number and Auth Level to be passed in as headers. This PR adds these.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
