### PR TITLE
NPA-2676 Update Request MimeType to handle `application/fhir+json`

### DIFF
--- a/proxies/live/apiproxy/policies/AssignMessage.SetRequestAWSMimeType.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.SetRequestAWSMimeType.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage async="false" continueOnError="false" enabled="true" name="SetRequestAWSMimeType">
+    <DisplayName>Set Request AWS Mime Type</DisplayName>
+    <Set>
+        <Headers>
+            <Header name="Content-Type">application/json</Header>
+        </Headers>
+    </Set>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    <AssignTo createNew="false" transport="http" type="response"/>
+</AssignMessage>

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -17,6 +17,10 @@
             <Step>
                 <Name>AddUserNHSNumber</Name>
             </Step>
+            <Step>
+                <Name>SetRequestAWSMimeType</Name>
+                <Condition>request.header.Content-Type = "application/fhir+json"</Condition>
+            </Step>
         </Request>
     </PreFlow>
     <PostFlow>


### PR DESCRIPTION
## Summary
* Routine Change

Updates the preflow for the target server so that any requests with `Content-Type: application/fhir+json` will be converted to `Content-Type: application/json` so AWS can easily transform the request for step functions


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
