### PR TITLE
NPA-3659: Refactoring/adding of OAS examples 

### DIFF
--- a/specification/examples/requests/POST_QuestionnaireResponse/adult-nominates-adult.yaml
+++ b/specification/examples/requests/POST_QuestionnaireResponse/adult-nominates-adult.yaml
@@ -1,0 +1,88 @@
+QuestionnaireResponseAdultNominatesAdultRequest:
+  summary: Adult nominates Adult access request
+  description: |
+    Example proxy access request from an adult (Jill) with NHS number `9000000006` nominating her husband (Tom) with NHS number `9000000005` to act on her behalf. 
+    
+    Significant things to point out:
+
+    - `source` should be the NHS number of the patient completing the form - this should correlate with the Identity token in the request
+    - `subject` should be the NHS Number of the patient to which the application relates
+    - `relatedPerson` demographics are present in the request as a result of being provided by the applicant
+  value: 
+    resourceType: QuestionnaireResponse        
+    status: "completed"
+    authored: "2024-07-15T09:43:03.280Z"
+    source:
+      identifier:
+        system: "https://fhir.nhs.uk/Id/nhs-number"
+        value: "9000000006"
+    subject:
+      identifier:
+        system: "https://fhir.nhs.uk/Id/nhs-number"
+        value: "9000000006"
+    questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
+    item:
+      - linkId: "relatedPerson"
+        text: "Proxy details"
+        item:
+          - linkId: "relatedPerson_identifier"
+            text: "NHS number"
+            answer:
+              - valueString: "9000000005"
+          - linkId: "relatedPerson_name"
+            text: "Name"
+            item:
+              - linkId: "relatedPerson_name_first"
+                text: "First name"
+                answer:
+                  - valueString: "Tom"
+              - linkId: "relatedPerson_name_family"
+                text: "Last name"
+                answer:
+                  - valueString: "Jones"
+          - linkId: "relatedPerson_birthDate"
+            text: "Date of birth"
+            answer:
+              - valueDate: "1970-07-12"
+          - linkId: "relatedPerson_basisForAccess"
+            text: "Basis for Access"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole"
+                  code: "Personal"
+                  display: "Personal relationship with the patient"
+          - linkId: "relatedPerson_relationship"
+            text: "Relationship"
+            answer:
+              - valueCoding:
+                  system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: "SPS"
+                  display: "Spouse"
+      - linkId: "patient"
+        text: "Patient details"
+        item:
+          - linkId: "patient_identifier"
+            text: "NHS number"
+            answer:
+              - valueString: "9000000006"
+      - linkId: "requestedAccess"
+        text: "Requested access"
+        item:
+          - linkId: "requestedAccess_accessLevel"
+            text: "Requested access level"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "APPT"
+                  display: "Appointment Booking"
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "VACC"
+                  display: "Vaccination Records"
+          - linkId: "requestedAccess_reasonsForAccess"
+            text: "Reason for access"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
+                  code: "PRAC"
+                  display: "Practical Reasons"

--- a/specification/examples/requests/POST_QuestionnaireResponse/adult-to-adult-with-capacity.yaml
+++ b/specification/examples/requests/POST_QuestionnaireResponse/adult-to-adult-with-capacity.yaml
@@ -1,0 +1,88 @@
+QuestionnaireResponseAdultToAdultWithCapacityRequest:
+  summary: Adult > Adult (with capacity) access request
+  description: |
+    Example proxy access request from an adult (Tom) with NHS number `9000000005` requesting access to act on behalf of his wife (Jill) with NHS number `9000000006`. 
+    
+    Significant details to point out:
+
+    - `source` should be the NHS number of the proxy completing the form - this should correlate with the Identity token in the request
+    - `subject` should be the NHS Number of the patient to which the application relates        
+    - `patient` demographics are present in the request as a result of being provided by the applicant
+  value: 
+    resourceType: QuestionnaireResponse        
+    status: "completed"
+    authored: "2024-07-15T09:43:03.280Z"
+    source:
+      identifier:
+        system: "https://fhir.nhs.uk/Id/nhs-number"
+        value: "9000000005"
+    subject:
+      identifier:
+        system: "https://fhir.nhs.uk/Id/nhs-number"
+        value: "9000000006"
+    questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
+    item:
+      - linkId: "relatedPerson"
+        text: "Proxy details"
+        item:
+          - linkId: "relatedPerson_identifier"
+            text: "NHS number"
+            answer:
+              - valueString: "9000000005"
+          - linkId: "relatedPerson_basisForAccess"
+            text: "Basis for Access"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole"
+                  code: "Personal"
+                  display: "Personal relationship with the patient"
+          - linkId: "relatedPerson_relationship"
+            text: "Relationship"
+            answer:
+              - valueCoding:
+                  system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: "SPS"
+                  display: "Spouse"
+      - linkId: "patient"
+        text: "Patient details"
+        item:
+          - linkId: "patient_identifier"
+            text: "NHS number"
+            answer:
+              - valueString: "9000000006"
+          - linkId: "patient_name"
+            text: "Name"
+            item:
+              - linkId: "patient_name_first"
+                text: "First name"
+                answer:
+                  - valueString: "Jill"
+              - linkId: "patient_name_family"
+                text: "Last name"
+                answer:
+                  - valueString: "Jones"
+          - linkId: "patient_birthDate"
+            text: "Date of birth"
+            answer:
+              - valueDate: "1965-01-01"
+      - linkId: "requestedAccess"
+        text: "Requested access"
+        item:
+          - linkId: "requestedAccess_accessLevel"
+            text: "Requested access level"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "APPT"
+                  display: "Appointment Booking"
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "VACC"
+                  display: "Vaccination Records"
+          - linkId: "requestedAccess_reasonsForAccess"
+            text: "Reason for access"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
+                  code: "PRAC"
+                  display: "Practical Reasons"

--- a/specification/examples/requests/POST_QuestionnaireResponse/adult-to-adult-without-capacity.yaml
+++ b/specification/examples/requests/POST_QuestionnaireResponse/adult-to-adult-without-capacity.yaml
@@ -1,0 +1,88 @@
+QuestionnaireResponseAdultToAdultWithoutCapacityRequest:
+  summary: Adult > Adult (without capacity) access request
+  description: |
+    Example proxy access request from an adult (Danny) with NHS number `9876543210` requesting access to act on behalf of an elderly parent (Florence) without capacity wth NHS number `9000000008`. 
+    
+    Significant details to point out:
+
+    - `source` should be the NHS number of the proxy completing the form - this should correlate with the Identity token in the request
+    - `subject` should be the NHS Number of the patient to which the application relates (the parent without capacity in this case)
+    - `patient` demographics are present in the request as a result of being provided by the applicant
+  value: 
+    resourceType: QuestionnaireResponse        
+    status: "completed"
+    authored: "2024-07-15T09:43:03.280Z"
+    source:
+      identifier:
+        system: "https://fhir.nhs.uk/Id/nhs-number"
+        value: "9876543210"
+    subject:
+      identifier:
+        system: "https://fhir.nhs.uk/Id/nhs-number"
+        value: "9000000008"
+    questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
+    item:
+      - linkId: "relatedPerson"
+        text: "Proxy details"
+        item:
+          - linkId: "relatedPerson_identifier"
+            text: "NHS number"
+            answer:
+              - valueString: "9876543210"
+          - linkId: "relatedPerson_basisForAccess"
+            text: "Basis for Access"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/STU3/CodeSystem/RARecord-ProxyRole-1"
+                  code: "002"
+                  display: "Best interest decision made on behalf of the patient (Mental Capacity Act 2005)"
+          - linkId: "relatedPerson_relationship"
+            text: "Relationship"
+            answer:
+              - valueCoding:
+                  system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: "CHILD"
+                  display: "Child"
+      - linkId: "patient"
+        text: "Patient details"
+        item:
+          - linkId: "patient_identifier"
+            text: "NHS number"
+            answer:
+              - valueString: "9000000008"
+          - linkId: "patient_name"
+            text: "Name"
+            item:
+              - linkId: "patient_name_first"
+                text: "First name"
+                answer:
+                  - valueString: "Florence"
+              - linkId: "patient_name_family"
+                text: "Last name"
+                answer:
+                  - valueString: "Smith"
+          - linkId: "patient_birthDate"
+            text: "Date of birth"
+            answer:
+              - valueDate: "1935-01-02"
+      - linkId: "requestedAccess"
+        text: "Requested access"
+        item:
+          - linkId: "requestedAccess_accessLevel"
+            text: "Requested access level"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "APPT"
+                  display: "Appointment Booking"
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "VACC"
+                  display: "Vaccination Records"
+          - linkId: "requestedAccess_reasonsForAccess"
+            text: "Reason for access"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
+                  code: "TECH"
+                  display: "Technical Barriers"

--- a/specification/examples/requests/POST_QuestionnaireResponse/mother-child.yaml
+++ b/specification/examples/requests/POST_QuestionnaireResponse/mother-child.yaml
@@ -1,0 +1,126 @@
+QuestionnaireResponseMotherChildRequest:
+  summary: Mother > Child access request
+  description: |
+    Example proxy access request from a mother (Martha) with NHS number `9000000001` requesting access to act on behalf of their child (Timmy) with NHS number `9000000002`. 
+    
+    Significant details to point out:
+
+    - `source` should be the NHS number of the proxy completing the form - this should correlate with the Identity token in the request
+    - `subject` should be the NHS Number of the patient to which the application relates (the child)
+    - `patient` demographics are present in the request as a result of being provided by the applicant
+  value: 
+    resourceType: QuestionnaireResponse        
+    status: "completed"
+    authored: "2024-07-15T09:43:03.280Z"
+    source:
+      identifier:
+        system: "https://fhir.nhs.uk/Id/nhs-number"
+        value: "9000000001"
+    subject:
+      identifier:
+        system: "https://fhir.nhs.uk/Id/nhs-number"
+        value: "9000000002"
+    questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
+    item:
+      - linkId: "relatedPerson"
+        text: "Proxy details"
+        item:
+          - linkId: "relatedPerson_identifier"
+            text: "NHS number"
+            answer:
+              - valueString: "9000000001"
+          - linkId: "relatedPerson_basisForAccess"
+            text: "Basis for Access"
+            answer:
+              - valueCoding:
+                  system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: "PRN"
+                  display: "Parent"
+          - linkId: "relatedPerson_relationship"
+            text: "Relationship"
+            answer:
+              - valueCoding:
+                  system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: "PRN"
+                  display: "Parent"
+      - linkId: "parentalApplicationSupplementaryDetails"
+        text: "Parental Application Supplementary Details"
+        item:
+          - linkId: "parentalApplicationSupplementaryDetails_evidenceOfResponsibility"
+            text: "Evidence of parental responsibility"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-EvidenceOfResponsibility"
+                  code: "BRTH"
+                  display: "Birth certificate"
+          - linkId: "parentalApplicationSupplementaryDetails_isCurrentAddressConfirmed"
+            text: "Is current address confirmed?"
+            answer:
+              - valueBoolean: true
+          - linkId: "parentalApplicationSupplementaryDetails_liveAtSameAddress"
+            text: "Do adult and child live at the same address?"
+            answer:
+              - valueBoolean: true
+      - linkId: "patient"
+        text: "Patient details"
+        item:
+          - linkId: "patient_identifier"
+            text: "NHS number"
+            answer:
+              - valueString: "9000000002"
+          - linkId: "patient_name"
+            text: "Name"
+            item:
+              - linkId: "patient_name_first"
+                text: "First name"
+                answer:
+                  - valueString: "Timothy"
+              - linkId: "patient_name_family"
+                text: "Last name"
+                answer:
+                  - valueString: "Tenenbaum"
+          - linkId: "patient_birthDate"
+            text: "Date of birth"
+            answer:
+              - valueDate: "2020-10-22"
+      - linkId: "requestedAccess"
+        text: "Requested access"
+        item:
+          - linkId: "requestedAccess_accessLevel"
+            text: "Requested access level"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "APPT"
+                  display: "Appointment Booking"
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "CNTCT"
+                  display: "Contacting Surgery"
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "RECRD"
+                  display: "Medical Records Access"
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "TEST"
+                  display: "Test Results"
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "VACC"
+                  display: "Vaccination Records"
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                  code: "PRESCR"
+                  display: "Repeat Prescription Requests"
+          - linkId: "requestedAccess_accessLevelMoreinfo"
+            text: "Requested access level - further information"
+            answer:
+              - valueString: "My child cannot access their own record"
+          - linkId: "requestedAccess_reasonsForAccess"
+            text: "Reason for access"
+            answer:
+              - valueCoding:
+                  system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
+                  code: "PRAC"
+                  display: "Practical Reasons"

--- a/specification/examples/responses/Errors/access-denied.yaml
+++ b/specification/examples/responses/Errors/access-denied.yaml
@@ -1,0 +1,14 @@
+AccessDeniedError:
+  summary: Access Denied
+  description: THe request was unsuccessful due to invalid authentication credentials being provided.
+  value:
+    resourceType: "OperationOutcome"
+    issue: 
+      - severity: error
+        code: invalid            
+        details:
+          coding:
+            - "system": "https://fhir.nhs.uk/R4/CodeSystem/ValidatedRelationships-ErrorOrWarningCode"
+              version: "1"
+              code: "ACCESS_DENIED"
+              display: "Missing or invalid OAuth 2.0 bearer token in request."  

--- a/specification/examples/responses/Errors/internal-server-error.yaml
+++ b/specification/examples/responses/Errors/internal-server-error.yaml
@@ -1,0 +1,15 @@
+InternalServerError:
+  summary: Internal Server Error
+  description: An unexpected condition was encountered preventing the server from fulfilling the request.
+  value:
+    resourceType: "OperationOutcome"
+    issue: 
+      - severity: error
+        code: invalid
+        diagnostics: "Internal Server Error - Failed to generate response is present in the response"          
+        details:
+          coding:
+            - system: "https://fhir.nhs.uk/R4/CodeSystem/ValidatedRelationships-ErrorOrWarningCode"
+              version: "1"
+              code: "SERVER_ERROR"
+              display: "Failed to generate response"

--- a/specification/examples/responses/GET_Consent/adults-consenting.yaml
+++ b/specification/examples/responses/GET_Consent/adults-consenting.yaml
@@ -1,0 +1,95 @@
+ConsentAdultsConsentingBundle:
+  summary: Bundle containing a single active proxy relationship for two consenting adults with capacity
+  value:
+    resourceType: Bundle
+    timestamp: "2020-08-26T14:00:00+00:00"
+    total: 1
+    type: searchset
+    entry:
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/RP974720"
+        resource:
+          resourceType: RelatedPerson
+          id: RP974720
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000010"
+            - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
+              value: "ABC0000008"
+          patient:
+            type: Patient
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000005"
+          relationship:
+            - coding:
+                - system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole"
+                  code: Personal
+                  display: "Personal relationship with the patient"                    
+        search:
+          mode: include
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/DFCC67F5"
+        resource:
+          resourceType: Patient
+          id: DFCC67F5
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000005"
+            - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
+              value: "ABC1234567"
+          name:
+            - id: "123456"
+              use: usual
+              period:
+                start: "2020-01-01"
+                end: "2021-12-31"
+              given:
+                - "Sally"
+              family: Evans
+              prefix:
+                - Mrs
+          birthDate: "1995-10-22"
+          generalPractitioner:
+            - type: "Organization"
+              identifier: 
+                value: "ODS12345"
+                system: "https://fhir.nhs.uk/Id/ods-organization-code"
+        search:
+          mode: include
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Consent/WWCC67T1"
+        resource:
+          resourceType: Consent
+          id: WWCC67T1
+          status: active
+          scope:
+            coding:
+              - system: "http://terminology.hl7.org/CodeSystem/consentscope"
+                code: patient-privacy
+                display: "Privacy Consent"
+            text: "Patient Privacy Consent"
+          category:
+            - coding:
+                - system: "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+                  code: INFA
+                  display: "Information Access"
+              text: "Information Access Consent"
+          patient:
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000005"
+          dateTime: "2024-07-21T17:32:28Z"
+          performer:
+            - identifier:
+                system: "https://fhir.nhs.uk/Id/nhs-number"
+                value: "9000000010"
+          policy:
+            - authority: "https://www.england.nhs.uk"
+              uri: "<REPLACE_WITH_LINK_TO_PUBLISHED_NATIONAL_PROXY_STANDARD>"
+          verification:
+            - verified: true
+              verifiedWith:
+                identifier:
+                  system: "https://fhir.nhs.uk/Id/nhs-number"
+                  value: "9000000005"
+              verificationDate: "2024-07-21T17:32:28Z"
+        search:
+          mode: match

--- a/specification/examples/responses/GET_Consent/mixed.yaml
+++ b/specification/examples/responses/GET_Consent/mixed.yaml
@@ -1,0 +1,182 @@
+ConsentMixedBundle:
+  summary: Mixed Bundle
+  description: A Bundle containing multiple active proxy relationships with varying legal basis'.
+  value:
+    resourceType: Bundle
+    timestamp: "2020-08-26T14:00:00+00:00"
+    total: 1
+    type: searchset
+    entry:
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
+        resource:
+          resourceType: RelatedPerson
+          id: BE974742
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000017"
+            - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
+              value: "ABC0000003"
+          patient:
+            type: Patient
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000009"
+          relationship:
+            - coding:
+                - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: PRN
+                  display: Parent
+                - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: MTH
+                  display: mother
+        search:
+          mode: include
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/A3CC67E2"
+        resource:
+          resourceType: Patient
+          id: A3CC67E2
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000009"
+            - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
+              value: "ABC1234567"
+          name:
+            - id: "123456"
+              use: usual
+              period:
+                start: "2020-01-01"
+                end: "2021-12-31"
+              given:
+                - "Jane Marie Anne"
+              family: Smith
+              prefix:
+                - Mrs
+              suffix:
+                - MBE
+                - PhD
+          birthDate: "2022-10-22"
+          generalPractitioner:
+            - type: "Organization"
+              identifier: 
+                value: "ODS12345"
+                system: "https://fhir.nhs.uk/Id/ods-organization-code"
+        search:
+          mode: include
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Consent/BBCC67E9"
+        resource:
+          resourceType: Consent
+          id: BBCC67E9
+          status: active
+          scope:
+            coding:
+              - system: "http://terminology.hl7.org/CodeSystem/consentscope"
+                code: patient-privacy
+                display: "Privacy Consent"
+            text: "Patient Privacy Consent"
+          category:
+            - coding:
+                - system: "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+                  code: INFA
+                  display: "Information Access"
+              text: "Information Access Consent"
+          patient:
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000009"
+          dateTime: "2024-07-21T17:32:28Z"
+          performer:
+            - identifier:
+                system: "https://fhir.nhs.uk/Id/nhs-number"
+                value: "9000000017"
+          policy:
+            - authority: "https://www.england.nhs.uk"
+              uri: "<REPLACE_WITH_LINK_TO_PUBLISHED_NATIONAL_PROXY_STANDARD>"
+        search:
+          mode: match
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/RP974720"
+        resource:
+          resourceType: RelatedPerson
+          id: RP974720
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000010"
+            - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
+              value: "ABC00000234"
+          patient:
+            type: Patient
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000005"
+          relationship:
+            - coding:
+                - system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole"
+                  code: Personal
+                  display: "Personal relationship with the patient"                    
+        search:
+          mode: include
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/DFCC67F5"
+        resource:
+          resourceType: Patient
+          id: DFCC67F5
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000005"
+            - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
+              value: "ABC9999999"
+          name:
+            - id: "123456"
+              use: usual
+              period:
+                start: "2020-01-01"
+                end: "2021-12-31"
+              given:
+                - "Sally"
+              family: Evans
+              prefix:
+                - Mrs
+          birthDate: "1995-10-22"
+          generalPractitioner:
+            - type: "Organization"
+              identifier: 
+                value: "ODS12345"
+                system: "https://fhir.nhs.uk/Id/ods-organization-code"
+        search:
+          mode: include
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Consent/WWCC67T1"
+        resource:
+          resourceType: Consent
+          id: WWCC67T1
+          status: active
+          scope:
+            coding:
+              - system: "http://terminology.hl7.org/CodeSystem/consentscope"
+                code: patient-privacy
+                display: "Privacy Consent"
+            text: "Patient Privacy Consent"
+          category:
+            - coding:
+                - system: "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+                  code: INFA
+                  display: "Information Access"
+              text: "Information Access Consent"
+          patient:
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000005"
+          dateTime: "2024-07-21T17:32:28Z"
+          performer:
+            - identifier:
+                system: "https://fhir.nhs.uk/Id/nhs-number"
+                value: "9000000010"
+          policy:
+            - authority: "https://www.england.nhs.uk"
+              uri: "<REPLACE_WITH_LINK_TO_PUBLISHED_NATIONAL_PROXY_STANDARD>"
+          verification:
+            - verified: true
+              verifiedWith:
+                identifier:
+                  system: "https://fhir.nhs.uk/Id/nhs-number"
+                  value: "9000000005"
+              verificationDate: "2024-07-21T17:32:28Z"
+        search:
+          mode: match

--- a/specification/examples/responses/GET_Consent/mother-child.yaml
+++ b/specification/examples/responses/GET_Consent/mother-child.yaml
@@ -1,0 +1,94 @@
+ConsentMotherChildBundle:
+  summary: Bundle containing a single active proxy relationship for a birth mother & child
+  value:
+    resourceType: Bundle
+    timestamp: "2020-08-26T14:00:00+00:00"
+    total: 1
+    type: searchset
+    entry:
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
+        resource:
+          resourceType: RelatedPerson
+          id: BE974742
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000017"
+            - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
+              value: "ABC0000001"
+          patient:
+            type: Patient
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000009"
+          relationship:
+            - coding:
+                - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: PRN
+                  display: Parent
+                - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: MTH
+                  display: mother
+        search:
+          mode: include
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/A3CC67E2"
+        resource:
+          resourceType: Patient
+          id: A3CC67E2
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000009"
+            - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
+              value: "ABC1234556"
+          name:
+            - id: "123456"
+              use: usual
+              period:
+                start: "2020-01-01"
+                end: "2021-12-31"
+              given:
+                - "Jane Marie Anne"
+              family: Smith
+              prefix:
+                - Mrs
+              suffix:
+                - MBE
+                - PhD
+          birthDate: "2022-10-22"
+          generalPractitioner:
+            - type: "Organization"
+              identifier: 
+                value: "ODS12345"
+                system: "https://fhir.nhs.uk/Id/ods-organization-code"
+        search:
+          mode: include
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Consent/BBCC67E9"
+        resource:
+          resourceType: Consent
+          id: BBCC67E9
+          status: active
+          scope:
+            coding:
+              - system: "http://terminology.hl7.org/CodeSystem/consentscope"
+                code: patient-privacy
+                display: "Privacy Consent"
+            text: "Patient Privacy Consent"
+          category:
+            - coding:
+                - system: "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+                  code: INFA
+                  display: "Information Access"
+              text: "Information Access Consent"
+          patient:
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000009"
+          dateTime: "2024-07-21T17:32:28Z"
+          performer:
+            - identifier:
+                system: "https://fhir.nhs.uk/Id/nhs-number"
+                value: "9000000017"
+          policy:
+            - authority: "https://www.england.nhs.uk"
+              uri: "<REPLACE_WITH_LINK_TO_PUBLISHED_NATIONAL_PROXY_STANDARD>"
+        search:
+          mode: match

--- a/specification/examples/responses/GET_RelatedPerson/errors/invalid-identifier.yaml
+++ b/specification/examples/responses/GET_RelatedPerson/errors/invalid-identifier.yaml
@@ -1,0 +1,16 @@
+RelatedPersonInvalidIdentifierError:
+  summary: Invalid RelatedPerson identifier
+  description: Error raised due to an invalid RelatedPerson identifier request parameter being specified.
+  value:
+    resourceType: "OperationOutcome"
+    issue: 
+      - severity: error
+        code: invalid
+        diagnostics: "Not a valid NHS Number provided for the 'identifier' parameter"            
+        expression: "RelatedPerson.identifier"
+        details:
+          coding:
+            - "system": "https://fhir.nhs.uk/R4/CodeSystem/ValidatedRelationships-ErrorOrWarningCode"
+              version: "1"
+              code: "INVALID_IDENTIFIER_VALUE"
+              display: "Provided value is invalid"

--- a/specification/examples/responses/GET_RelatedPerson/include-patients.yaml
+++ b/specification/examples/responses/GET_RelatedPerson/include-patients.yaml
@@ -1,0 +1,60 @@
+RelatedPersonIncludePatients:
+  summary: With patient '_include'
+  description: |
+    Example response containing the details of a single matched candidate proxy relationship between a birth mother and her child.
+    
+    The FHIR Bundle contains a `RelatedPerson` and a `Patient` resource per relationship verified against authoritative sources. 
+    
+    `Patient` resources are included in the bundle when the `_include=RelatedPerson:patient` query parameter is specified.
+  value:
+    resourceType: Bundle
+    timestamp: "2020-08-26T14:00:00+00:00"
+    total: 1
+    type: searchset
+    link:
+      - relation: self
+        url: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson?_include=RelatedPerson%3apatient&identifier=https%3A%2F%2Ffhir.nhs.uk%2FId%2Fnhs-number%7C9000000017"
+    entry:
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
+        resource:
+          resourceType: RelatedPerson
+          id: BE974742
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000017"
+          patient:
+            type: Patient
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000009"
+          relationship:
+            - coding:
+                - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: MTH
+                  display: mother
+        search:
+          mode: match
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/A3CC67E2"
+        resource:
+          resourceType: Patient
+          id: A3CC67E2
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000009"
+          name:
+            - id: "123"
+              use: usual
+              period:
+                start: "2020-01-01"
+                end: "2021-12-31"
+              given:
+                - Jane Marie Anne
+              family: Smith
+              prefix:
+                - Mrs
+              suffix:
+                - MBE
+                - PhD
+          birthDate: "2010-10-22"
+        search:
+          mode: include

--- a/specification/examples/responses/GET_RelatedPerson/without-patients.yaml
+++ b/specification/examples/responses/GET_RelatedPerson/without-patients.yaml
@@ -1,0 +1,55 @@
+RelatedPersonWithoutPatients:
+  summary: Default behaviour
+  description: |
+    Example response containing the details of two matched candidate proxy relationships between a birth mother and her two children.
+    
+    The FHIR Bundle contains a `RelatedPerson` resource per relationship verified against authoritative sources. 
+    
+    `Patient` resources are not included by default.
+  value:
+    resourceType: Bundle
+    timestamp: "2020-08-26T14:00:00+00:00"
+    total: 2
+    type: searchset
+    link:
+      - relation: self
+        url: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson?_include=RelatedPerson%3apatient&identifier=https%3A%2F%2Ffhir.nhs.uk%2FId%2Fnhs-number%7C9000000017"
+    entry:
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
+        resource:
+          resourceType: RelatedPerson
+          id: BE974742
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000017"
+          patient:
+            type: Patient
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000009"
+          relationship:
+            - coding:
+                - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: MTH
+                  display: mother
+        search:
+          mode: match
+      - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974741"
+        resource:
+          resourceType: RelatedPerson
+          id: BE974741
+          identifier:
+            - system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000017"
+          patient:
+            type: Patient
+            identifier:
+              system: "https://fhir.nhs.uk/Id/nhs-number"
+              value: "9000000002"
+          relationship:
+            - coding:
+                - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                  code: MTH
+                  display: mother
+        search:
+          mode: match

--- a/specification/examples/responses/POST_QuestionnaireResponse/success.yaml
+++ b/specification/examples/responses/POST_QuestionnaireResponse/success.yaml
@@ -1,0 +1,12 @@
+PostQuestionnaireResponseSuccess:
+  summary: Success
+  description: A sample of the payload returned when a QuestionnaireResponse (proxy access request) has been successfully submitted. It contains a unique alpha-numeric reference code to identify the request by.
+  value:
+    resourceType: "OperationOutcome"
+    issue: 
+      - severity: information
+        code: informational
+        details:
+          coding:
+            - code: "HDJ2123F"
+              display: "HDJ2123F"    

--- a/specification/validated-relationships-service-api.yaml
+++ b/specification/validated-relationships-service-api.yaml
@@ -227,6 +227,9 @@ paths:
             application/fhir+json:
               schema:
                 $ref: '#/components/schemas/OperationOutcome'
+              examples:
+                accessDeniedError:
+                  $ref: '#/components/examples/AccessDeniedError' 
         "500":
           description: Internal server error
           content:
@@ -295,6 +298,12 @@ paths:
             application/fhir+json:
               schema:
                 $ref: '#/components/schemas/OperationOutcome'
+              examples:
+                accessDeniedError:
+                  $ref: '#/components/examples/AccessDeniedError'  
+                relatedPersonInvalidIdentifierError:
+                  $ref: '#/components/examples/RelatedPersonInvalidIdentifierError'
+
         "500":
           description: Internal server error
           content:
@@ -369,6 +378,9 @@ paths:
               application/fhir+json:
                 schema:
                   $ref: '#/components/schemas/OperationOutcome'
+                examples:
+                  accessDeniedError:
+                    $ref: '#/components/examples/AccessDeniedError' 
           "500":
             description: Internal server error
             content:
@@ -2743,6 +2755,7 @@ components:
               mode: match
 
     InternalServerError:
+      summary: Internal Eerver Error
       value:
         resourceType: "OperationOutcome"
         issue: 
@@ -2755,8 +2768,41 @@ components:
                  version: "1"
                  code: "SERVER_ERROR"
                  display: "Failed to generate response"
-    
+
+    AccessDeniedError:
+      summary: Access Denied
+      value:
+        resourceType: "OperationOutcome"
+        issue: 
+          - severity: error
+            code: invalid            
+            details:
+              coding:
+               - "system": "https://fhir.nhs.uk/R4/CodeSystem/ValidatedRelationships-ErrorOrWarningCode"
+                 version: "1"
+                 code: "ACCESS_DENIED"
+                 display: "Missing or invalid OAuth 2.0 bearer token in request."              
+          
+    RelatedPersonInvalidIdentifierError:
+      summary: Invalid RelatedPerson identifier
+      description: Error raised due to an invalid RelatedPerson identifier being specified in the request.
+      value:
+        resourceType: "OperationOutcome"
+        issue: 
+          - severity: error
+            code: invalid
+            diagnostics: "Not a valid NHS Number provided for the 'identifier' parameter"            
+            expression: "RelatedPerson.identifier"
+            details:
+              coding:
+               - "system": "https://fhir.nhs.uk/R4/CodeSystem/ValidatedRelationships-ErrorOrWarningCode"
+                 version: "1"
+                 code: "INVALID_IDENTIFIER_VALUE"
+                 display: "Provided value is invalid"
+
     PostQuestionnaireResponseSuccess:
+      summary: Success
+      description: A sample of the payload returned when a QuestionnaireResponse (proxy access request) has been successfully submitted. It contains a unique alpha-numeric reference code to identify the request by.
       value:
         resourceType: "OperationOutcome"
         issue: 

--- a/specification/validated-relationships-service-api.yaml
+++ b/specification/validated-relationships-service-api.yaml
@@ -266,7 +266,12 @@ paths:
           content:
             application/fhir+json:
               schema:
-                $ref: "#/components/schemas/RelatedPersonBundle"              
+                $ref: "#/components/schemas/RelatedPersonBundle"
+              examples:
+                relatedPersonDefault:
+                  $ref: '#/components/examples/RelatedPersonDefault'                  
+                relatedPersonIncludePatientLinks:
+                  $ref: '#/components/examples/RelatedPersonIncludePatientLinks'
 
         "4XX":
           description: |
@@ -1164,12 +1169,10 @@ components:
           type: string
           format: date-time
           description: The UTC date and time the search results were returned.
-          example: 2020-08-26T14:00:00+00:00
         total:
           type: number
           description: |
             The number of resources contained within the Bundle.
-          example: 2
 
     Searchset:
       allOf:
@@ -1196,11 +1199,9 @@ components:
                     description: |
                       Links related to this Bundle - see:
                       http://www.iana.org/assignments/link-relations/link-relations.xhtml
-                    example: "self"
                   url:
                     type: string
                     format: uri
-                    example: https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson?_include=RelatedPerson%3apatient&identifier=https%3A%2F%2Ffhir.nhs.uk%2FId%2Fnhs-number%7C9000000017
             entry:
               type: array
               description: |
@@ -1236,7 +1237,6 @@ components:
         fullUrl:
           type: string
           description: The canonical URL of the resource in the entry
-          example: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
         resource:
           $ref: "#/components/schemas/RelatedPerson"                        
         search:
@@ -1248,7 +1248,6 @@ components:
                 - match
                 - include
                 - outcome
-              example: match
 
     PatientBundleEntry: 
       type: object
@@ -1257,7 +1256,6 @@ components:
         fullUrl:
           type: string
           description: The canonical URL of the resource in the entry
-          example: https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/A3CC67E2
         resource:          
           $ref: "#/components/schemas/Patient"          
         search:
@@ -1269,7 +1267,6 @@ components:
                 - match
                 - include
                 - outcome
-              example: match
 
     ConsentBundleEntry: 
       type: object
@@ -1289,7 +1286,6 @@ components:
                 - match
                 - include
                 - outcome
-              example: match
 
     RelatedPerson:
       type: object
@@ -1303,7 +1299,6 @@ components:
         id:
           type: string
           description: Unique identifier of the RelatedPerson resource.
-          example: BE974742
         identifier:
           type: array
           description: The proxy's NHS number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a [valid NHS number](https://www.datadictionary.nhs.uk/attributes/nhs_number.html).
@@ -1317,7 +1312,6 @@ components:
               value:
                 type: string
                 description: The proxy's NHS number.
-                example: "9000000017"
         patient:
           type: object
           description: A reference to a patient the proxy is related to.
@@ -1337,7 +1331,6 @@ components:
                 value:
                   type: string
                   description: The patient's NHS number.
-                  example: "9000000009"
         relationship:
           type: array
           description: How the proxy is related to the patient.
@@ -1382,7 +1375,6 @@ components:
         id:
           type: string
           description: Unique identifier of the Patient resource
-          example: A3CC67E2
         identifier:
           type: array
           description: The patient's NHS number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a [valid NHS number](https://www.datadictionary.nhs.uk/attributes/nhs_number.html).
@@ -1396,7 +1388,6 @@ components:
               value:
                 type: string
                 description: The NHS number.
-                example: "9000000009"
         name:
           type: array
           description: List of names associated with the patient.
@@ -1410,7 +1401,6 @@ components:
               id:
                 type: string
                 description: Unique object identifier for this name.
-                example: "123"
               use:
                 type: string
                 description: |
@@ -1425,7 +1415,6 @@ components:
                   * official - The formal name as registered in an official (government) registry, but which name might not be commonly used. May be called "legal name".
                   * anonymous - Anonymous assigned name, alias, or pseudonym (used to protect a person's identity for privacy reasons).
                 enum: [usual, temp, nickname, old, maiden]
-                example: usual
               period:
                 type: object
                 description: |
@@ -1437,12 +1426,10 @@ components:
                     type: string
                     format: date
                     description: Start date of time period, if known, in format `yyyy-mm-dd`. Can be a future date.
-                    example: 2020-01-01
                   end:
                     type: string
                     format: date
                     description: End date of time period, if known and if not ongoing, in format `yyyy-mm-dd`. Can be a future date.
-                    example: 2021-12-31
               given:
                 type: array
                 maxItems: 5
@@ -1452,36 +1439,28 @@ components:
                   Each name(s) should be a separate item in the list. The first given name may include multiple names, separated by a space.
                   Subsequent names must be broken down into list items. For example, the input `[Jane Marie Anne, Jo Adele]` returns `[Jane Marie Anne, Jo, Adele]`.
 
-                example: [Jane Marie Anne]
                 items:
                   type: string
                   maxLength: 35
-                  example: Jane
               family:
                 type: string
                 maxLength: 35
                 description: Family name (often called Surname).
-                example: Smith
               prefix:
                 type: array
                 description: Name prefixes, titles, and prenominals.
-                example: [Mrs]
                 items:
                   type: string
-                  example: Mrs
               suffix:
                 type: array
                 description: Name suffices and postnominals.
-                example: [MBE, PhD]
                 items:
                   type: string
-                  example: MBE
         birthDate:
           description: |
             The date on which the patient was born or is officially deemed to have been born.
 
             It is a date in the format `yyyy-mm-dd`. Due to data quality issues on a small number of patients `yyyy-mm` and `yyyy` format may also be returned.
-          example: "2010-10-22"
           type: string
           format: date
         generalPractitioner:
@@ -1589,11 +1568,9 @@ components:
                 type: string
                 enum: [fatal, error, warning, information]
                 description: Severity of the error.
-                example: error
               code:
                 type: string
                 description: FHIR error code.
-                example: invalid
                 enum:
                   - invalid
                   - structure
@@ -1638,19 +1615,15 @@ components:
                         system:
                           type: string
                           description: URI of the coding system specification.
-                          example: https://fhir.nhs.uk/R4/CodeSystem/ValidatedRelationships-ErrorOrWarningCode
                         version:
                           type: string
                           description: Version of the coding system in use.
-                          example: '1'
                         code:
                           type: string
                           description: Symbol in syntax defined by the system.
-                          example: ACCESS_DENIED
                         display:
                           type: string
                           description: Representation defined by the system.
-                          example: Missing or invalid OAuth 2.0 bearer token in request.
               diagnostics:
                 type: string
                 description: Additional diagnostic information about the issue. This information is subject to change.                
@@ -1885,6 +1858,123 @@ components:
         example: NiV3CyMJH3xYV26ghlVpbbjT7pDVEA8HpFczAjRLTs1VezC4CYzupZ3XxXAWM7ELuseqrV8r0Ill7EL7G2tXUaVHCPWgg4q10+MxFjnRPrjDvckBRSZazqZcp0K2VBdUV0rZ7RUYJNJsjVAeefWhiK/Y4R+GFO86QDpt41JS9xA=;G123456
 
   examples:
+    RelatedPersonDefault:
+      summary: Default behaviour
+      description: |
+        Example response containing the details of two matched candidate proxy relationships between a birth mother and her two children.
+        
+        The FHIR Bundle contains a `RelatedPerson` resource per relationship verified against authoritative sources. 
+        
+        `Patient` resources are not included by default.
+      value:
+        resourceType: Bundle
+        timestamp: "2020-08-26T14:00:00+00:00"
+        total: 2
+        type: searchset
+        link:
+          - relation: self
+            url: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson?_include=RelatedPerson%3apatient&identifier=https%3A%2F%2Ffhir.nhs.uk%2FId%2Fnhs-number%7C9000000017"
+        entry:
+          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
+            resource:
+              resourceType: RelatedPerson
+              id: BE974742
+              identifier:
+                - system: "https://fhir.nhs.uk/Id/nhs-number"
+                  value: "9000000017"
+              patient:
+                type: Patient
+                identifier:
+                  system: "https://fhir.nhs.uk/Id/nhs-number"
+                  value: "9000000009"
+              relationship:
+                - coding:
+                    - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                      code: MTH
+                      display: mother
+            search:
+              mode: match
+          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974741"
+            resource:
+              resourceType: RelatedPerson
+              id: BE974741
+              identifier:
+                - system: "https://fhir.nhs.uk/Id/nhs-number"
+                  value: "9000000017"
+              patient:
+                type: Patient
+                identifier:
+                  system: "https://fhir.nhs.uk/Id/nhs-number"
+                  value: "9000000002"
+              relationship:
+                - coding:
+                    - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                      code: MTH
+                      display: mother
+            search:
+              mode: match
+
+    RelatedPersonIncludePatientLinks:
+      summary: With patient '_include'
+      description: |
+        Example response containing the details of a single matched candidate proxy relationship between a birth mother and her child.
+        
+        The FHIR Bundle contains a `RelatedPerson` and a `Patient` resource per relationship verified against authoritative sources. 
+        
+        `Patient` resources are included in the bundle when the `_include=RelatedPerson:patient` query parameter is specified.
+      value:
+        resourceType: Bundle
+        timestamp: "2020-08-26T14:00:00+00:00"
+        total: 1
+        type: searchset
+        link:
+          - relation: self
+            url: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson?_include=RelatedPerson%3apatient&identifier=https%3A%2F%2Ffhir.nhs.uk%2FId%2Fnhs-number%7C9000000017"
+        entry:
+          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
+            resource:
+              resourceType: RelatedPerson
+              id: BE974742
+              identifier:
+                - system: "https://fhir.nhs.uk/Id/nhs-number"
+                  value: "9000000017"
+              patient:
+                type: Patient
+                identifier:
+                  system: "https://fhir.nhs.uk/Id/nhs-number"
+                  value: "9000000009"
+              relationship:
+                - coding:
+                    - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                      code: MTH
+                      display: mother
+            search:
+              mode: match
+          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/A3CC67E2"
+            resource:
+              resourceType: Patient
+              id: A3CC67E2
+              identifier:
+                - system: "https://fhir.nhs.uk/Id/nhs-number"
+                  value: "9000000009"
+              name:
+                - id: "123"
+                  use: usual
+                  period:
+                    start: "2020-01-01"
+                    end: "2021-12-31"
+                  given:
+                    - Jane Marie Anne
+                  family: Smith
+                  prefix:
+                    - Mrs
+                  suffix:
+                    - MBE
+                    - PhD
+              birthDate: "2010-10-22"
+            search:
+              mode: include
+
     QuestionnaireResponseMotherChildRequest:
       summary: Mother > Child access request
       description: |

--- a/specification/validated-relationships-service-api.yaml
+++ b/specification/validated-relationships-service-api.yaml
@@ -178,25 +178,25 @@ paths:
               $ref: '#/components/schemas/QuestionnaireResponse'
             examples:
               questionnaireResponseMotherChildRequest:
-                $ref: '#/components/examples/QuestionnaireResponseMotherChildRequest'
+                $ref: './examples/requests/POST_QuestionnaireResponse/mother-child.yaml#/QuestionnaireResponseMotherChildRequest'
               questionnaireResponseAdultToAdultWithoutCapacityRequest:
-                $ref: '#/components/examples/QuestionnaireResponseAdultToAdultWithoutCapacityRequest'
+                $ref: './examples/requests/POST_QuestionnaireResponse/adult-to-adult-without-capacity.yaml#/QuestionnaireResponseAdultToAdultWithoutCapacityRequest'
               questionnaireResponseAdultToAdultWithCapacityRequest:
-                $ref: '#/components/examples/QuestionnaireResponseAdultToAdultWithCapacityRequest'
+                $ref: './examples/requests/POST_QuestionnaireResponse/adult-to-adult-with-capacity.yaml#/QuestionnaireResponseAdultToAdultWithCapacityRequest'
               questionnaireResponseAdultNominatesAdultRequest:
-                $ref: '#/components/examples/QuestionnaireResponseAdultNominatesAdultRequest'
+                $ref: './examples/requests/POST_QuestionnaireResponse/adult-nominates-adult.yaml#/QuestionnaireResponseAdultNominatesAdultRequest'
           application/fhir+json; charset=utf-8:
             schema: 
               $ref: '#/components/schemas/QuestionnaireResponse'
             examples:
               questionnaireResponseMotherChildRequest:
-                $ref: '#/components/examples/QuestionnaireResponseMotherChildRequest'
+                $ref: './examples/requests/POST_QuestionnaireResponse/mother-child.yaml#/QuestionnaireResponseMotherChildRequest'
               questionnaireResponseAdultToAdultWithoutCapacityRequest:
-                $ref: '#/components/examples/QuestionnaireResponseAdultToAdultWithoutCapacityRequest'
+                $ref: './examples/requests/POST_QuestionnaireResponse/adult-to-adult-without-capacity.yaml#/QuestionnaireResponseAdultToAdultWithoutCapacityRequest'
               questionnaireResponseAdultToAdultWithCapacityRequest:
-                $ref: '#/components/examples/QuestionnaireResponseAdultToAdultWithCapacityRequest'
+                $ref: './examples/requests/POST_QuestionnaireResponse/adult-to-adult-with-capacity.yaml#/QuestionnaireResponseAdultToAdultWithCapacityRequest'
               questionnaireResponseAdultNominatesAdultRequest:
-                $ref: '#/components/examples/QuestionnaireResponseAdultNominatesAdultRequest'
+                $ref: './examples/requests/POST_QuestionnaireResponse/adult-nominates-adult.yaml#/QuestionnaireResponseAdultNominatesAdultRequest'
       responses:
         '200':
           description: Request was received successfully for processing
@@ -206,7 +206,7 @@ paths:
                 $ref: '#/components/schemas/OperationOutcome'
               examples:
                 postQuestionnaireResponseSuccess:
-                  $ref: '#/components/examples/PostQuestionnaireResponseSuccess'
+                  $ref: './examples/responses/POST_QuestionnaireResponse/success.yaml#/PostQuestionnaireResponseSuccess'
         "4XX":
           description: |
             Errors will be returned for the first error encountered in the request. An error occurred as follows:
@@ -229,7 +229,7 @@ paths:
                 $ref: '#/components/schemas/OperationOutcome'
               examples:
                 accessDeniedError:
-                  $ref: '#/components/examples/AccessDeniedError' 
+                  $ref: './examples/responses/errors/access-denied.yaml#/AccessDeniedError' 
         "500":
           description: Internal server error
           content:
@@ -238,7 +238,7 @@ paths:
                 $ref: '#/components/schemas/OperationOutcome'
               examples:  
                 internalServerError:
-                  $ref: '#/components/examples/InternalServerError'
+                  $ref: './examples/responses/errors/internal-server-error.yaml#/InternalServerError'
 
   /RelatedPerson:
     get:
@@ -271,10 +271,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/RelatedPersonBundle"
               examples:
-                relatedPersonDefault:
-                  $ref: '#/components/examples/RelatedPersonDefault'                  
-                relatedPersonIncludePatientLinks:
-                  $ref: '#/components/examples/RelatedPersonIncludePatientLinks'
+                relatedPersonWithoutPatients:
+                  $ref: './examples/responses/GET_RelatedPerson/without-patients.yaml#/RelatedPersonWithoutPatients'
+                relatedPersonIncludePatients:
+                  $ref: './examples/responses/GET_RelatedPerson/include-patients.yaml#/RelatedPersonIncludePatients'
 
         "4XX":
           description: |
@@ -300,9 +300,9 @@ paths:
                 $ref: '#/components/schemas/OperationOutcome'
               examples:
                 accessDeniedError:
-                  $ref: '#/components/examples/AccessDeniedError'  
+                  $ref: './examples/responses/errors/access-denied.yaml#/AccessDeniedError'  
                 relatedPersonInvalidIdentifierError:
-                  $ref: '#/components/examples/RelatedPersonInvalidIdentifierError'
+                  $ref: './examples/responses/GET_RelatedPerson/errors/invalid-identifier.yaml#/RelatedPersonInvalidIdentifierError'
 
         "500":
           description: Internal server error
@@ -312,7 +312,7 @@ paths:
                 $ref: '#/components/schemas/OperationOutcome'
               examples:  
                 internalServerError:
-                  $ref: '#/components/examples/InternalServerError'
+                  $ref: './examples/responses/errors/internal-server-error.yaml#/InternalServerError'
 
   /Consent:
     get:
@@ -349,11 +349,11 @@ paths:
                   $ref: "#/components/schemas/ConsentBundle"
                 examples: 
                   consentMotherChildBundle:
-                    $ref: "#/components/examples/ConsentMotherChildBundle"
+                    $ref: "./examples/responses/GET_Consent/mother-child.yaml#/ConsentMotherChildBundle"
                   consentAdultsConsentingBundle:
-                    $ref: "#/components/examples/ConsentAdultsConsentingBundle"
+                    $ref: "./examples/responses/GET_Consent/adults-consenting.yaml#/ConsentAdultsConsentingBundle"
                   consentMultipleBundle:
-                    $ref: "#/components/examples/ConsentMultipleBundle"
+                    $ref: "./examples/responses/GET_Consent/mixed.yaml#/ConsentMixedBundle"
 
           "4XX":
             description: |
@@ -380,7 +380,7 @@ paths:
                   $ref: '#/components/schemas/OperationOutcome'
                 examples:
                   accessDeniedError:
-                    $ref: '#/components/examples/AccessDeniedError' 
+                    $ref: './examples/responses/errors/access-denied.yaml#/AccessDeniedError' 
           "500":
             description: Internal server error
             content:
@@ -389,7 +389,7 @@ paths:
                   $ref: '#/components/schemas/OperationOutcome'
                 examples:  
                   internalServerError:
-                    $ref: '#/components/examples/InternalServerError'
+                    $ref: './examples/responses/errors/internal-server-error.yaml#/InternalServerError'
 
 
 components:
@@ -1868,947 +1868,3 @@ components:
         type: string        
         pattern: "^[^;]+;[^;]+$"
         example: NiV3CyMJH3xYV26ghlVpbbjT7pDVEA8HpFczAjRLTs1VezC4CYzupZ3XxXAWM7ELuseqrV8r0Ill7EL7G2tXUaVHCPWgg4q10+MxFjnRPrjDvckBRSZazqZcp0K2VBdUV0rZ7RUYJNJsjVAeefWhiK/Y4R+GFO86QDpt41JS9xA=;G123456
-
-  examples:
-    RelatedPersonDefault:
-      summary: Default behaviour
-      description: |
-        Example response containing the details of two matched candidate proxy relationships between a birth mother and her two children.
-        
-        The FHIR Bundle contains a `RelatedPerson` resource per relationship verified against authoritative sources. 
-        
-        `Patient` resources are not included by default.
-      value:
-        resourceType: Bundle
-        timestamp: "2020-08-26T14:00:00+00:00"
-        total: 2
-        type: searchset
-        link:
-          - relation: self
-            url: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson?_include=RelatedPerson%3apatient&identifier=https%3A%2F%2Ffhir.nhs.uk%2FId%2Fnhs-number%7C9000000017"
-        entry:
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
-            resource:
-              resourceType: RelatedPerson
-              id: BE974742
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000017"
-              patient:
-                type: Patient
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000009"
-              relationship:
-                - coding:
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: MTH
-                      display: mother
-            search:
-              mode: match
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974741"
-            resource:
-              resourceType: RelatedPerson
-              id: BE974741
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000017"
-              patient:
-                type: Patient
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000002"
-              relationship:
-                - coding:
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: MTH
-                      display: mother
-            search:
-              mode: match
-
-    RelatedPersonIncludePatientLinks:
-      summary: With patient '_include'
-      description: |
-        Example response containing the details of a single matched candidate proxy relationship between a birth mother and her child.
-        
-        The FHIR Bundle contains a `RelatedPerson` and a `Patient` resource per relationship verified against authoritative sources. 
-        
-        `Patient` resources are included in the bundle when the `_include=RelatedPerson:patient` query parameter is specified.
-      value:
-        resourceType: Bundle
-        timestamp: "2020-08-26T14:00:00+00:00"
-        total: 1
-        type: searchset
-        link:
-          - relation: self
-            url: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson?_include=RelatedPerson%3apatient&identifier=https%3A%2F%2Ffhir.nhs.uk%2FId%2Fnhs-number%7C9000000017"
-        entry:
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
-            resource:
-              resourceType: RelatedPerson
-              id: BE974742
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000017"
-              patient:
-                type: Patient
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000009"
-              relationship:
-                - coding:
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: MTH
-                      display: mother
-            search:
-              mode: match
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/A3CC67E2"
-            resource:
-              resourceType: Patient
-              id: A3CC67E2
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000009"
-              name:
-                - id: "123"
-                  use: usual
-                  period:
-                    start: "2020-01-01"
-                    end: "2021-12-31"
-                  given:
-                    - Jane Marie Anne
-                  family: Smith
-                  prefix:
-                    - Mrs
-                  suffix:
-                    - MBE
-                    - PhD
-              birthDate: "2010-10-22"
-            search:
-              mode: include
-
-    QuestionnaireResponseMotherChildRequest:
-      summary: Mother > Child access request
-      description: |
-        Example proxy access request from a mother (Martha) with NHS number `9000000001` requesting access to act on behalf of their child (Timmy) with NHS number `9000000002`. 
-        
-        Significant details to point out:
-
-        - `source` should be the NHS number of the proxy completing the form - this should correlate with the Identity token in the request
-        - `subject` should be the NHS Number of the patient to which the application relates (the child)
-        - `patient` demographics are present in the request as a result of being provided by the applicant
-      value: 
-        resourceType: QuestionnaireResponse        
-        status: "completed"
-        authored: "2024-07-15T09:43:03.280Z"
-        source:
-          identifier:
-            system: "https://fhir.nhs.uk/Id/nhs-number"
-            value: "9000000001"
-        subject:
-          identifier:
-            system: "https://fhir.nhs.uk/Id/nhs-number"
-            value: "9000000002"
-        questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
-        item:
-          - linkId: "relatedPerson"
-            text: "Proxy details"
-            item:
-              - linkId: "relatedPerson_identifier"
-                text: "NHS number"
-                answer:
-                  - valueString: "9000000001"
-              - linkId: "relatedPerson_basisForAccess"
-                text: "Basis for Access"
-                answer:
-                  - valueCoding:
-                      system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: "PRN"
-                      display: "Parent"
-              - linkId: "relatedPerson_relationship"
-                text: "Relationship"
-                answer:
-                  - valueCoding:
-                      system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: "PRN"
-                      display: "Parent"
-          - linkId: "parentalApplicationSupplementaryDetails"
-            text: "Parental Application Supplementary Details"
-            item:
-              - linkId: "parentalApplicationSupplementaryDetails_evidenceOfResponsibility"
-                text: "Evidence of parental responsibility"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-EvidenceOfResponsibility"
-                      code: "BRTH"
-                      display: "Birth certificate"
-              - linkId: "parentalApplicationSupplementaryDetails_isCurrentAddressConfirmed"
-                text: "Is current address confirmed?"
-                answer:
-                  - valueBoolean: true
-              - linkId: "parentalApplicationSupplementaryDetails_liveAtSameAddress"
-                text: "Do adult and child live at the same address?"
-                answer:
-                  - valueBoolean: true
-          - linkId: "patient"
-            text: "Patient details"
-            item:
-              - linkId: "patient_identifier"
-                text: "NHS number"
-                answer:
-                  - valueString: "9000000002"
-              - linkId: "patient_name"
-                text: "Name"
-                item:
-                  - linkId: "patient_name_first"
-                    text: "First name"
-                    answer:
-                      - valueString: "Timothy"
-                  - linkId: "patient_name_family"
-                    text: "Last name"
-                    answer:
-                      - valueString: "Tenenbaum"
-              - linkId: "patient_birthDate"
-                text: "Date of birth"
-                answer:
-                  - valueDate: "2020-10-22"
-          - linkId: "requestedAccess"
-            text: "Requested access"
-            item:
-              - linkId: "requestedAccess_accessLevel"
-                text: "Requested access level"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "APPT"
-                      display: "Appointment Booking"
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "CNTCT"
-                      display: "Contacting Surgery"
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "RECRD"
-                      display: "Medical Records Access"
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "TEST"
-                      display: "Test Results"
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "VACC"
-                      display: "Vaccination Records"
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "PRESCR"
-                      display: "Repeat Prescription Requests"
-              - linkId: "requestedAccess_accessLevelMoreinfo"
-                text: "Requested access level - further information"
-                answer:
-                  - valueString: "My child cannot access their own record"
-              - linkId: "requestedAccess_reasonsForAccess"
-                text: "Reason for access"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
-                      code: "PRAC"
-                      display: "Practical Reasons"
-
-    QuestionnaireResponseAdultToAdultWithoutCapacityRequest:
-      summary: Adult > Adult (without capacity) access request
-      description: |
-        Example proxy access request from an adult (Danny) with NHS number `9876543210` requesting access to act on behalf of an elderly parent (Florence) without capacity wth NHS number `9000000008`. 
-        
-        Significant details to point out:
-
-        - `source` should be the NHS number of the proxy completing the form - this should correlate with the Identity token in the request
-        - `subject` should be the NHS Number of the patient to which the application relates (the parent without capacity in this case)
-        - `patient` demographics are present in the request as a result of being provided by the applicant
-      value: 
-        resourceType: QuestionnaireResponse        
-        status: "completed"
-        authored: "2024-07-15T09:43:03.280Z"
-        source:
-          identifier:
-            system: "https://fhir.nhs.uk/Id/nhs-number"
-            value: "9876543210"
-        subject:
-          identifier:
-            system: "https://fhir.nhs.uk/Id/nhs-number"
-            value: "9000000008"
-        questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
-        item:
-          - linkId: "relatedPerson"
-            text: "Proxy details"
-            item:
-              - linkId: "relatedPerson_identifier"
-                text: "NHS number"
-                answer:
-                  - valueString: "9876543210"
-              - linkId: "relatedPerson_basisForAccess"
-                text: "Basis for Access"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/STU3/CodeSystem/RARecord-ProxyRole-1"
-                      code: "002"
-                      display: "Best interest decision made on behalf of the patient (Mental Capacity Act 2005)"
-              - linkId: "relatedPerson_relationship"
-                text: "Relationship"
-                answer:
-                  - valueCoding:
-                      system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: "CHILD"
-                      display: "Child"
-          - linkId: "patient"
-            text: "Patient details"
-            item:
-              - linkId: "patient_identifier"
-                text: "NHS number"
-                answer:
-                  - valueString: "9000000008"
-              - linkId: "patient_name"
-                text: "Name"
-                item:
-                  - linkId: "patient_name_first"
-                    text: "First name"
-                    answer:
-                      - valueString: "Florence"
-                  - linkId: "patient_name_family"
-                    text: "Last name"
-                    answer:
-                      - valueString: "Smith"
-              - linkId: "patient_birthDate"
-                text: "Date of birth"
-                answer:
-                  - valueDate: "1935-01-02"
-          - linkId: "requestedAccess"
-            text: "Requested access"
-            item:
-              - linkId: "requestedAccess_accessLevel"
-                text: "Requested access level"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "APPT"
-                      display: "Appointment Booking"
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "VACC"
-                      display: "Vaccination Records"
-              - linkId: "requestedAccess_reasonsForAccess"
-                text: "Reason for access"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
-                      code: "TECH"
-                      display: "Technical Barriers"
-
-    QuestionnaireResponseAdultToAdultWithCapacityRequest:
-      summary: Adult > Adult (with capacity) access request
-      description: |
-        Example proxy access request from an adult (Tom) with NHS number `9000000005` requesting access to act on behalf of his wife (Jill) with NHS number `9000000006`. 
-        
-        Significant details to point out:
-
-        - `source` should be the NHS number of the proxy completing the form - this should correlate with the Identity token in the request
-        - `subject` should be the NHS Number of the patient to which the application relates        
-        - `patient` demographics are present in the request as a result of being provided by the applicant
-      value: 
-        resourceType: QuestionnaireResponse        
-        status: "completed"
-        authored: "2024-07-15T09:43:03.280Z"
-        source:
-          identifier:
-            system: "https://fhir.nhs.uk/Id/nhs-number"
-            value: "9000000005"
-        subject:
-          identifier:
-            system: "https://fhir.nhs.uk/Id/nhs-number"
-            value: "9000000006"
-        questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
-        item:
-          - linkId: "relatedPerson"
-            text: "Proxy details"
-            item:
-              - linkId: "relatedPerson_identifier"
-                text: "NHS number"
-                answer:
-                  - valueString: "9000000005"
-              - linkId: "relatedPerson_basisForAccess"
-                text: "Basis for Access"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole"
-                      code: "Personal"
-                      display: "Personal relationship with the patient"
-              - linkId: "relatedPerson_relationship"
-                text: "Relationship"
-                answer:
-                  - valueCoding:
-                      system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: "SPS"
-                      display: "Spouse"
-          - linkId: "patient"
-            text: "Patient details"
-            item:
-              - linkId: "patient_identifier"
-                text: "NHS number"
-                answer:
-                  - valueString: "9000000006"
-              - linkId: "patient_name"
-                text: "Name"
-                item:
-                  - linkId: "patient_name_first"
-                    text: "First name"
-                    answer:
-                      - valueString: "Jill"
-                  - linkId: "patient_name_family"
-                    text: "Last name"
-                    answer:
-                      - valueString: "Jones"
-              - linkId: "patient_birthDate"
-                text: "Date of birth"
-                answer:
-                  - valueDate: "1965-01-01"
-          - linkId: "requestedAccess"
-            text: "Requested access"
-            item:
-              - linkId: "requestedAccess_accessLevel"
-                text: "Requested access level"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "APPT"
-                      display: "Appointment Booking"
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "VACC"
-                      display: "Vaccination Records"
-              - linkId: "requestedAccess_reasonsForAccess"
-                text: "Reason for access"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
-                      code: "PRAC"
-                      display: "Practical Reasons"
-
-    QuestionnaireResponseAdultNominatesAdultRequest:
-      summary: Adult nominates Adult access request
-      description: |
-        Example proxy access request from an adult (Jill) with NHS number `9000000006` nominating her husband (Tom) with NHS number `9000000005` to act on her behalf. 
-        
-        Significant things to point out:
-
-        - `source` should be the NHS number of the patient completing the form - this should correlate with the Identity token in the request
-        - `subject` should be the NHS Number of the patient to which the application relates
-        - `relatedPerson` demographics are present in the request as a result of being provided by the applicant
-      value: 
-        resourceType: QuestionnaireResponse        
-        status: "completed"
-        authored: "2024-07-15T09:43:03.280Z"
-        source:
-          identifier:
-            system: "https://fhir.nhs.uk/Id/nhs-number"
-            value: "9000000006"
-        subject:
-          identifier:
-            system: "https://fhir.nhs.uk/Id/nhs-number"
-            value: "9000000006"
-        questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
-        item:
-          - linkId: "relatedPerson"
-            text: "Proxy details"
-            item:
-              - linkId: "relatedPerson_identifier"
-                text: "NHS number"
-                answer:
-                  - valueString: "9000000005"
-              - linkId: "relatedPerson_name"
-                text: "Name"
-                item:
-                  - linkId: "relatedPerson_name_first"
-                    text: "First name"
-                    answer:
-                      - valueString: "Tom"
-                  - linkId: "relatedPerson_name_family"
-                    text: "Last name"
-                    answer:
-                      - valueString: "Jones"
-              - linkId: "relatedPerson_birthDate"
-                text: "Date of birth"
-                answer:
-                  - valueDate: "1970-07-12"
-              - linkId: "relatedPerson_basisForAccess"
-                text: "Basis for Access"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole"
-                      code: "Personal"
-                      display: "Personal relationship with the patient"
-              - linkId: "relatedPerson_relationship"
-                text: "Relationship"
-                answer:
-                  - valueCoding:
-                      system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: "SPS"
-                      display: "Spouse"
-          - linkId: "patient"
-            text: "Patient details"
-            item:
-              - linkId: "patient_identifier"
-                text: "NHS number"
-                answer:
-                  - valueString: "9000000006"
-          - linkId: "requestedAccess"
-            text: "Requested access"
-            item:
-              - linkId: "requestedAccess_accessLevel"
-                text: "Requested access level"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "APPT"
-                      display: "Appointment Booking"
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
-                      code: "VACC"
-                      display: "Vaccination Records"
-              - linkId: "requestedAccess_reasonsForAccess"
-                text: "Reason for access"
-                answer:
-                  - valueCoding:
-                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
-                      code: "PRAC"
-                      display: "Practical Reasons"
-
-    ConsentMotherChildBundle:
-      summary: Bundle containing a single active proxy relationship for a birth mother & child
-      value:
-        resourceType: Bundle
-        timestamp: "2020-08-26T14:00:00+00:00"
-        total: 1
-        type: searchset
-        entry:
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
-            resource:
-              resourceType: RelatedPerson
-              id: BE974742
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000017"
-                - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
-                  value: "ABC0000001"
-              patient:
-                type: Patient
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000009"
-              relationship:
-                - coding:
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: PRN
-                      display: Parent
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: MTH
-                      display: mother
-            search:
-              mode: include
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/A3CC67E2"
-            resource:
-              resourceType: Patient
-              id: A3CC67E2
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000009"
-                - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
-                  value: "ABC1234556"
-              name:
-                - id: "123456"
-                  use: usual
-                  period:
-                    start: "2020-01-01"
-                    end: "2021-12-31"
-                  given:
-                    - "Jane Marie Anne"
-                  family: Smith
-                  prefix:
-                    - Mrs
-                  suffix:
-                    - MBE
-                    - PhD
-              birthDate: "2022-10-22"
-              generalPractitioner:
-                - type: "Organization"
-                  identifier: 
-                    value: "ODS12345"
-                    system: "https://fhir.nhs.uk/Id/ods-organization-code"
-            search:
-              mode: include
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Consent/BBCC67E9"
-            resource:
-              resourceType: Consent
-              id: BBCC67E9
-              status: active
-              scope:
-                coding:
-                  - system: "http://terminology.hl7.org/CodeSystem/consentscope"
-                    code: patient-privacy
-                    display: "Privacy Consent"
-                text: "Patient Privacy Consent"
-              category:
-                - coding:
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-ActCode"
-                      code: INFA
-                      display: "Information Access"
-                  text: "Information Access Consent"
-              patient:
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000009"
-              dateTime: "2024-07-21T17:32:28Z"
-              performer:
-                - identifier:
-                    system: "https://fhir.nhs.uk/Id/nhs-number"
-                    value: "9000000017"
-              policy:
-                - authority: "https://www.england.nhs.uk"
-                  uri: "<REPLACE_WITH_LINK_TO_PUBLISHED_NATIONAL_PROXY_STANDARD>"
-            search:
-              mode: match
-
-    ConsentAdultsConsentingBundle:
-      summary: Bundle containing a single active proxy relationship for two consenting adults with capacity
-      value:
-        resourceType: Bundle
-        timestamp: "2020-08-26T14:00:00+00:00"
-        total: 1
-        type: searchset
-        entry:
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/RP974720"
-            resource:
-              resourceType: RelatedPerson
-              id: RP974720
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000010"
-                - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
-                  value: "ABC0000008"
-              patient:
-                type: Patient
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000005"
-              relationship:
-                - coding:
-                    - system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole"
-                      code: Personal
-                      display: "Personal relationship with the patient"                    
-            search:
-              mode: include
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/DFCC67F5"
-            resource:
-              resourceType: Patient
-              id: DFCC67F5
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000005"
-                - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
-                  value: "ABC1234567"
-              name:
-                - id: "123456"
-                  use: usual
-                  period:
-                    start: "2020-01-01"
-                    end: "2021-12-31"
-                  given:
-                    - "Sally"
-                  family: Evans
-                  prefix:
-                    - Mrs
-              birthDate: "1995-10-22"
-              generalPractitioner:
-                - type: "Organization"
-                  identifier: 
-                    value: "ODS12345"
-                    system: "https://fhir.nhs.uk/Id/ods-organization-code"
-            search:
-              mode: include
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Consent/WWCC67T1"
-            resource:
-              resourceType: Consent
-              id: WWCC67T1
-              status: active
-              scope:
-                coding:
-                  - system: "http://terminology.hl7.org/CodeSystem/consentscope"
-                    code: patient-privacy
-                    display: "Privacy Consent"
-                text: "Patient Privacy Consent"
-              category:
-                - coding:
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-ActCode"
-                      code: INFA
-                      display: "Information Access"
-                  text: "Information Access Consent"
-              patient:
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000005"
-              dateTime: "2024-07-21T17:32:28Z"
-              performer:
-                - identifier:
-                    system: "https://fhir.nhs.uk/Id/nhs-number"
-                    value: "9000000010"
-              policy:
-                - authority: "https://www.england.nhs.uk"
-                  uri: "<REPLACE_WITH_LINK_TO_PUBLISHED_NATIONAL_PROXY_STANDARD>"
-              verification:
-                - verified: true
-                  verifiedWith:
-                    identifier:
-                      system: "https://fhir.nhs.uk/Id/nhs-number"
-                      value: "9000000005"
-                  verificationDate: "2024-07-21T17:32:28Z"
-            search:
-              mode: match
-
-    ConsentMultipleBundle:
-      summary: Bundle containing a multiple active proxy relationships
-      value:
-        resourceType: Bundle
-        timestamp: "2020-08-26T14:00:00+00:00"
-        total: 1
-        type: searchset
-        entry:
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/BE974742"
-            resource:
-              resourceType: RelatedPerson
-              id: BE974742
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000017"
-                - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
-                  value: "ABC0000003"
-              patient:
-                type: Patient
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000009"
-              relationship:
-                - coding:
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: PRN
-                      display: Parent
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
-                      code: MTH
-                      display: mother
-            search:
-              mode: include
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/A3CC67E2"
-            resource:
-              resourceType: Patient
-              id: A3CC67E2
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000009"
-                - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
-                  value: "ABC1234567"
-              name:
-                - id: "123456"
-                  use: usual
-                  period:
-                    start: "2020-01-01"
-                    end: "2021-12-31"
-                  given:
-                    - "Jane Marie Anne"
-                  family: Smith
-                  prefix:
-                    - Mrs
-                  suffix:
-                    - MBE
-                    - PhD
-              birthDate: "2022-10-22"
-              generalPractitioner:
-                - type: "Organization"
-                  identifier: 
-                    value: "ODS12345"
-                    system: "https://fhir.nhs.uk/Id/ods-organization-code"
-            search:
-              mode: include
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Consent/BBCC67E9"
-            resource:
-              resourceType: Consent
-              id: BBCC67E9
-              status: active
-              scope:
-                coding:
-                  - system: "http://terminology.hl7.org/CodeSystem/consentscope"
-                    code: patient-privacy
-                    display: "Privacy Consent"
-                text: "Patient Privacy Consent"
-              category:
-                - coding:
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-ActCode"
-                      code: INFA
-                      display: "Information Access"
-                  text: "Information Access Consent"
-              patient:
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000009"
-              dateTime: "2024-07-21T17:32:28Z"
-              performer:
-                - identifier:
-                    system: "https://fhir.nhs.uk/Id/nhs-number"
-                    value: "9000000017"
-              policy:
-                - authority: "https://www.england.nhs.uk"
-                  uri: "<REPLACE_WITH_LINK_TO_PUBLISHED_NATIONAL_PROXY_STANDARD>"
-            search:
-              mode: match
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/RelatedPerson/RP974720"
-            resource:
-              resourceType: RelatedPerson
-              id: RP974720
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000010"
-                - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
-                  value: "ABC00000234"
-              patient:
-                type: Patient
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000005"
-              relationship:
-                - coding:
-                    - system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole"
-                      code: Personal
-                      display: "Personal relationship with the patient"                    
-            search:
-              mode: include
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Patient/DFCC67F5"
-            resource:
-              resourceType: Patient
-              id: DFCC67F5
-              identifier:
-                - system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000005"
-                - system: "https://placeholder.fhir.nhs.uk/Id/local-gp-patient-identifier"
-                  value: "ABC9999999"
-              name:
-                - id: "123456"
-                  use: usual
-                  period:
-                    start: "2020-01-01"
-                    end: "2021-12-31"
-                  given:
-                    - "Sally"
-                  family: Evans
-                  prefix:
-                    - Mrs
-              birthDate: "1995-10-22"
-              generalPractitioner:
-                - type: "Organization"
-                  identifier: 
-                    value: "ODS12345"
-                    system: "https://fhir.nhs.uk/Id/ods-organization-code"
-            search:
-              mode: include
-          - fullUrl: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Consent/WWCC67T1"
-            resource:
-              resourceType: Consent
-              id: WWCC67T1
-              status: active
-              scope:
-                coding:
-                  - system: "http://terminology.hl7.org/CodeSystem/consentscope"
-                    code: patient-privacy
-                    display: "Privacy Consent"
-                text: "Patient Privacy Consent"
-              category:
-                - coding:
-                    - system: "http://terminology.hl7.org/CodeSystem/v3-ActCode"
-                      code: INFA
-                      display: "Information Access"
-                  text: "Information Access Consent"
-              patient:
-                identifier:
-                  system: "https://fhir.nhs.uk/Id/nhs-number"
-                  value: "9000000005"
-              dateTime: "2024-07-21T17:32:28Z"
-              performer:
-                - identifier:
-                    system: "https://fhir.nhs.uk/Id/nhs-number"
-                    value: "9000000010"
-              policy:
-                - authority: "https://www.england.nhs.uk"
-                  uri: "<REPLACE_WITH_LINK_TO_PUBLISHED_NATIONAL_PROXY_STANDARD>"
-              verification:
-                - verified: true
-                  verifiedWith:
-                    identifier:
-                      system: "https://fhir.nhs.uk/Id/nhs-number"
-                      value: "9000000005"
-                  verificationDate: "2024-07-21T17:32:28Z"
-            search:
-              mode: match
-
-    InternalServerError:
-      summary: Internal Eerver Error
-      value:
-        resourceType: "OperationOutcome"
-        issue: 
-          - severity: error
-            code: invalid
-            diagnostics: "Internal Server Error - Failed to generate response is present in the response"          
-            details:
-              coding:
-               - system: "https://fhir.nhs.uk/R4/CodeSystem/ValidatedRelationships-ErrorOrWarningCode"
-                 version: "1"
-                 code: "SERVER_ERROR"
-                 display: "Failed to generate response"
-
-    AccessDeniedError:
-      summary: Access Denied
-      value:
-        resourceType: "OperationOutcome"
-        issue: 
-          - severity: error
-            code: invalid            
-            details:
-              coding:
-               - "system": "https://fhir.nhs.uk/R4/CodeSystem/ValidatedRelationships-ErrorOrWarningCode"
-                 version: "1"
-                 code: "ACCESS_DENIED"
-                 display: "Missing or invalid OAuth 2.0 bearer token in request."              
-          
-    RelatedPersonInvalidIdentifierError:
-      summary: Invalid RelatedPerson identifier
-      description: Error raised due to an invalid RelatedPerson identifier being specified in the request.
-      value:
-        resourceType: "OperationOutcome"
-        issue: 
-          - severity: error
-            code: invalid
-            diagnostics: "Not a valid NHS Number provided for the 'identifier' parameter"            
-            expression: "RelatedPerson.identifier"
-            details:
-              coding:
-               - "system": "https://fhir.nhs.uk/R4/CodeSystem/ValidatedRelationships-ErrorOrWarningCode"
-                 version: "1"
-                 code: "INVALID_IDENTIFIER_VALUE"
-                 display: "Provided value is invalid"
-
-    PostQuestionnaireResponseSuccess:
-      summary: Success
-      description: A sample of the payload returned when a QuestionnaireResponse (proxy access request) has been successfully submitted. It contains a unique alpha-numeric reference code to identify the request by.
-      value:
-        resourceType: "OperationOutcome"
-        issue: 
-          - severity: information
-            code: informational
-            details:
-              coding:
-               - code: "HDJ2123F"
-                 display: "HDJ2123F"    

--- a/specification/validated-relationships-service-api.yaml
+++ b/specification/validated-relationships-service-api.yaml
@@ -176,9 +176,27 @@ paths:
           application/fhir+json:
             schema:
               $ref: '#/components/schemas/QuestionnaireResponse'
+            examples:
+              questionnaireResponseMotherChildRequest:
+                $ref: '#/components/examples/QuestionnaireResponseMotherChildRequest'
+              questionnaireResponseAdultToAdultWithoutCapacityRequest:
+                $ref: '#/components/examples/QuestionnaireResponseAdultToAdultWithoutCapacityRequest'
+              questionnaireResponseAdultToAdultWithCapacityRequest:
+                $ref: '#/components/examples/QuestionnaireResponseAdultToAdultWithCapacityRequest'
+              questionnaireResponseAdultNominatesAdultRequest:
+                $ref: '#/components/examples/QuestionnaireResponseAdultNominatesAdultRequest'
           application/fhir+json; charset=utf-8:
             schema: 
               $ref: '#/components/schemas/QuestionnaireResponse'
+            examples:
+              questionnaireResponseMotherChildRequest:
+                $ref: '#/components/examples/QuestionnaireResponseMotherChildRequest'
+              questionnaireResponseAdultToAdultWithoutCapacityRequest:
+                $ref: '#/components/examples/QuestionnaireResponseAdultToAdultWithoutCapacityRequest'
+              questionnaireResponseAdultToAdultWithCapacityRequest:
+                $ref: '#/components/examples/QuestionnaireResponseAdultToAdultWithCapacityRequest'
+              questionnaireResponseAdultNominatesAdultRequest:
+                $ref: '#/components/examples/QuestionnaireResponseAdultNominatesAdultRequest'
       responses:
         '200':
           description: Request was received successfully for processing
@@ -248,7 +266,8 @@ paths:
           content:
             application/fhir+json:
               schema:
-                $ref: "#/components/schemas/RelatedPersonBundle"
+                $ref: "#/components/schemas/RelatedPersonBundle"              
+
         "4XX":
           description: |
             Errors will be returned for the first error encountered in the request. An error occurred as follows:
@@ -380,7 +399,6 @@ components:
           type: string
           format: date-time
           description: The date time that this set of answers were last changed.
-          example: "2024-07-15T09:43:03.280Z"
         source: 
           type: object
           description: The person who answered the questions about the subject.
@@ -400,7 +418,6 @@ components:
                 value:
                   type: string
                   description: The source's NHS number.
-                  example: "9000000001"
         subject: 
           type: object
           description: The person who is the subject.
@@ -420,11 +437,9 @@ components:
                 value:
                   type: string
                   description: The subject's NHS number.
-                  example: "9000000002"
         questionnaire:
           type: string
           description: The Questionnaire that defines and organizes the questions for which answers are being provided.
-          example: "Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
         item:
           type: array
           description: A group or question item from the original questionnaire for which answers are provided.
@@ -447,7 +462,6 @@ components:
           enum: ["relatedPerson"]
         text:
           type: string
-          example: "relatedPerson"
         item:
           type: array
           items:
@@ -463,7 +477,6 @@ components:
                     enum: ["relatedPerson_identifier"]
                   text:
                     type: string
-                    example: "NHS Number"
                   answer:
                     type: array
                     minItems: 1
@@ -474,7 +487,6 @@ components:
                           properties:
                             valueString:
                               type: string
-                              example: "9000000001"
 
               - type: object
                 properties:
@@ -483,7 +495,6 @@ components:
                     enum: ["relatedPerson_name"]
                   text:
                     type: string
-                    example: "relatedPerson_name"
                   item:
                     type: array
                     minItems: 2
@@ -501,7 +512,6 @@ components:
                               enum: ["relatedPerson_name_first"]
                             text:
                               type: string
-                              example: "First name."
                             answer:
                               type: array
                               minItems: 1
@@ -512,7 +522,6 @@ components:
                                     properties:
                                       valueString:
                                         type: string
-                                        example: "Sharon"
 
                         - type: object
                           required:
@@ -525,7 +534,6 @@ components:
                               enum: ["relatedPerson_name_family"]
                             text:
                               type: string
-                              example: "Family name (often called Surname)."
                             answer:
                               type: array
                               minItems: 1
@@ -536,7 +544,6 @@ components:
                                     properties:
                                       valueString:
                                         type: string
-                                        example: "Smith"
 
               - type: object
                 properties:
@@ -545,7 +552,6 @@ components:
                     enum: ["relatedPerson_birthDate"]
                   text:
                     type: string
-                    example: "Date of Birth"
                   answer:
                     type: array
                     minItems: 1
@@ -557,7 +563,6 @@ components:
                             valueDate:
                               type: string
                               format: date
-                              example: "1994-03-21"
 
               - type: object
                 required:
@@ -570,7 +575,6 @@ components:
                     enum: ["relatedPerson_basisForAccess"]
                   text:
                     type: string
-                    example: "Basis For Access"
                   answer:
                     type: array
                     minItems: 1
@@ -609,7 +613,6 @@ components:
                     enum: ["relatedPerson_relationship"]
                   text:
                     type: string
-                    example: "Relationship"
                   answer:
                     type: array
                     minItems: 1
@@ -644,7 +647,6 @@ components:
                     enum: ["relatedPerson_relationshipMoreinfo"]
                   text:
                     type: string
-                    example: "Relationship - further information"
                   answer:
                     type: array
                     maxItems: 1
@@ -663,7 +665,6 @@ components:
           enum: ["parentalApplicationSupplementaryDetails"]
         text:
           type: string
-          example: "parentalApplicationSupplementaryDetails"
         item:
           type: array
           items:
@@ -679,7 +680,6 @@ components:
                     enum: ["parentalApplicationSupplementaryDetails_evidenceOfResponsibility"]
                   text:
                     type: string
-                    example: "Evidence of parental responsibility"
                   answer:
                     type: array
                     description: A multiple option selection where multiple items of evidence can be selected
@@ -708,7 +708,6 @@ components:
                     enum: ["parentalApplicationSupplementaryDetails_evidenceOfResponsibilityMoreinfo"]
                   text:
                     type: string
-                    example: "Evidence of responsibility - Further Information"
                   answer:
                     type: array
                     items:
@@ -717,7 +716,6 @@ components:
                           properties:
                             valueString:
                               type: string
-                              example: "Birth Certificate is original"
               - type: object
                 required:
                   - linkId
@@ -729,7 +727,6 @@ components:
                     enum: ["parentalApplicationSupplementaryDetails_isCurrentAddressConfirmed"]
                   text:
                     type: string
-                    example: "Is current address confirmed?"
                   answer:
                     type: array
                     items:
@@ -738,7 +735,6 @@ components:
                           properties:
                             valueString:
                               type: string
-                              example: "Yes"                                    
 
               - type: object
                 properties:
@@ -747,7 +743,6 @@ components:
                     enum: ["parentalApplicationSupplementaryDetails_newAddress"]
                   text:
                     type: string
-                    example: "parentalApplicationSupplementaryDetails_newAddress"
                   item:
                     type: array
                     items:
@@ -759,7 +754,6 @@ components:
                               enum: ["parentalApplicationSupplementaryDetails_line1"]
                             text:
                               type: string
-                              example: "Address Line 1"
                             answer:
                               type: array
                               items:
@@ -768,7 +762,6 @@ components:
                                     properties:
                                       valueString:
                                         type: string
-                                        example: "24 Hoves Edge"
                         - type: object
                           properties:
                             linkId:
@@ -776,7 +769,6 @@ components:
                               enum: ["parentalApplicationSupplementaryDetails_line2"]
                             text:
                               type: string
-                              example: "Address Line 2"
                             answer:
                               type: array
                               items:
@@ -785,7 +777,6 @@ components:
                                     properties:
                                       valueString:
                                         type: string
-                                        example: "Remington"
                         - type: object
                           properties:
                             linkId:
@@ -793,7 +784,6 @@ components:
                               enum: ["parentalApplicationSupplementaryDetails_line3"]
                             text:
                               type: string
-                              example: "Address Line 3"
                             answer:
                               type: array
                               items:
@@ -802,7 +792,6 @@ components:
                                     properties:
                                       valueString:
                                         type: string
-                                        example: "Boroughbridge"
 
                         - type: object
                           properties:
@@ -811,7 +800,6 @@ components:
                               enum: ["parentalApplicationSupplementaryDetails_city"]
                             text:
                               type: string
-                              example: "Town / City"
                             answer:
                               type: array
                               items:
@@ -820,7 +808,6 @@ components:
                                     properties:
                                       valueString:
                                         type: string
-                                        example: "Leeds"
                         - type: object
                           properties:
                             linkId:
@@ -828,7 +815,6 @@ components:
                               enum: ["parentalApplicationSupplementaryDetails_district"]
                             text:
                               type: string
-                              example: "County"
                             answer:
                               type: array
                               items:
@@ -837,7 +823,6 @@ components:
                                     properties:
                                       valueString:
                                         type: string
-                                        example: "West Yorkshire"
                         - type: object
                           properties:
                             linkId:
@@ -845,7 +830,6 @@ components:
                               enum: ["parentalApplicationSupplementaryDetails_postalCode"]
                             text:
                               type: string
-                              example: "Postcode"
                             answer:
                               type: array
                               items:
@@ -854,7 +838,6 @@ components:
                                     properties:
                                       valueString:
                                         type: string
-                                        example: "LS1 1DW"
 
               - type: object
                 required:
@@ -867,7 +850,6 @@ components:
                     enum: ["parentalApplicationSupplementaryDetails_liveAtSameAddress"]
                   text:
                     type: string
-                    example: "Do the adult and child live at the same address?"
                   answer:
                     type: array
                     items:
@@ -876,7 +858,6 @@ components:
                           properties:
                             valueString:
                               type: string
-                              example: "Yes"
 
               - type: object
                 required:
@@ -889,7 +870,6 @@ components:
                     enum: ["parentalApplicationSupplementaryDetails_canChildConsent"]
                   text:
                     type: string
-                    example: "Can the child consent?"
                   answer:
                     type: array
                     items:
@@ -898,7 +878,6 @@ components:
                           properties:
                             valueString:
                               type: string
-                              example: "No"
               - type: object
                 properties:
                   linkId:
@@ -906,7 +885,6 @@ components:
                     enum: ["parentalApplicationSupplementaryDetails_reasonNoChildConsent"]
                   text:
                     type: string
-                    example: "Reason the child cannot consent"
                   answer:
                     type: array
                     items:
@@ -915,7 +893,6 @@ components:
                           properties:
                             valueString:
                               type: string
-                              example: "Child is too young"
 
     QuestionnaireResponseItem_Patient:
       type: object
@@ -929,7 +906,6 @@ components:
           enum: ["patient"]
         text:
           type: string
-          example: "patient"
         item:
           type: array
           items:
@@ -945,7 +921,6 @@ components:
                     enum: ["patient_identifier"]
                   text:
                     type: string
-                    example: "NHS Number"
                   answer:
                     type: array
                     minItems: 1
@@ -956,7 +931,6 @@ components:
                           properties:
                             valueString:
                               type: string
-                              example: "9000000002"
 
               - type: object
                 properties:
@@ -965,7 +939,6 @@ components:
                     enum: ["patient_name"]
                   text:
                     type: string
-                    example: "patient_name"
                   item:
                     type: array
                     minItems: 2
@@ -983,7 +956,6 @@ components:
                               enum: ["patient_name_first"]
                             text:
                               type: string
-                              example: "First name."
                             answer:
                               type: array
                               minItems: 1
@@ -994,7 +966,6 @@ components:
                                     properties:
                                       valueString:
                                         type: string
-                                        example: "Jane"
                                         
                         - type: object
                           required:
@@ -1007,7 +978,6 @@ components:
                               enum: ["patient_name_family"]
                             text:
                               type: string
-                              example: "Family name (often called Surname)."
                             answer:
                               type: array
                               minItems: 1
@@ -1018,7 +988,6 @@ components:
                                     properties:
                                       valueString:
                                         type: string
-                                        example: "Smith"
 
               - type: object
                 properties:
@@ -1027,7 +996,6 @@ components:
                     enum: ["patient_birthDate"]
                   text:
                     type: string
-                    example: "Date of Birth"
                   answer:
                     type: array
                     minItems: 1
@@ -1039,7 +1007,6 @@ components:
                             valueDate:
                               type: string
                               format: date
-                              example: "2020-10-22"
 
     QuestionnaireResponseItem_RequestedAccess:
       type: object
@@ -1053,7 +1020,6 @@ components:
           enum: ["requestedAccess"]
         text:
           type: string
-          example: "requestedAccess"
         item:
           type: array
           items:
@@ -1069,7 +1035,6 @@ components:
                     enum: ["requestedAccess_accessLevel"]
                   text:
                     type: string
-                    example: "Requested access level"
                   answer:
                     type: array
                     minItems: 1
@@ -1111,7 +1076,6 @@ components:
                     enum: ["requestedAccess_accessLevelMoreinfo"]
                   text:
                     type: string
-                    example: "Requested access level - further information"
                   answer:
                     type: array
                     items:
@@ -1120,7 +1084,6 @@ components:
                           properties:
                             valueString:
                               type: string
-                              example: "Access only required to most recent 3 years"
 
               - type: object
                 required:
@@ -1133,7 +1096,6 @@ components:
                     enum: ["requestedAccess_reasonsForAccess"]
                   text:
                     type: string
-                    example: "Reason for access"
                   answer:
                     type: array
                     minItems: 1
@@ -1181,7 +1143,6 @@ components:
                     enum: ["requestedAccess_reasonsForAccessMoreinfo"]
                   text:
                     type: string
-                    example: "Reason for access - further information"
                   answer:
                     type: array
                     items:
@@ -1190,7 +1151,6 @@ components:
                           properties:
                             valueString:
                               type: string
-                              example: "No internet connection"
     
     BaseBundle: 
       type: object
@@ -1925,6 +1885,400 @@ components:
         example: NiV3CyMJH3xYV26ghlVpbbjT7pDVEA8HpFczAjRLTs1VezC4CYzupZ3XxXAWM7ELuseqrV8r0Ill7EL7G2tXUaVHCPWgg4q10+MxFjnRPrjDvckBRSZazqZcp0K2VBdUV0rZ7RUYJNJsjVAeefWhiK/Y4R+GFO86QDpt41JS9xA=;G123456
 
   examples:
+    QuestionnaireResponseMotherChildRequest:
+      summary: Mother > Child access request
+      description: |
+        Example proxy access request from a mother (Martha) with NHS number `9000000001` requesting access to act on behalf of their child (Timmy) with NHS number `9000000002`. 
+        
+        Significant details to point out:
+
+        - `source` should be the NHS number of the proxy completing the form - this should correlate with the Identity token in the request
+        - `subject` should be the NHS Number of the patient to which the application relates (the child)
+        - `patient` demographics are present in the request as a result of being provided by the applicant
+      value: 
+        resourceType: QuestionnaireResponse        
+        status: "completed"
+        authored: "2024-07-15T09:43:03.280Z"
+        source:
+          identifier:
+            system: "https://fhir.nhs.uk/Id/nhs-number"
+            value: "9000000001"
+        subject:
+          identifier:
+            system: "https://fhir.nhs.uk/Id/nhs-number"
+            value: "9000000002"
+        questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
+        item:
+          - linkId: "relatedPerson"
+            text: "Proxy details"
+            item:
+              - linkId: "relatedPerson_identifier"
+                text: "NHS number"
+                answer:
+                  - valueString: "9000000001"
+              - linkId: "relatedPerson_basisForAccess"
+                text: "Basis for Access"
+                answer:
+                  - valueCoding:
+                      system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                      code: "PRN"
+                      display: "Parent"
+              - linkId: "relatedPerson_relationship"
+                text: "Relationship"
+                answer:
+                  - valueCoding:
+                      system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                      code: "PRN"
+                      display: "Parent"
+          - linkId: "parentalApplicationSupplementaryDetails"
+            text: "Parental Application Supplementary Details"
+            item:
+              - linkId: "parentalApplicationSupplementaryDetails_evidenceOfResponsibility"
+                text: "Evidence of parental responsibility"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-EvidenceOfResponsibility"
+                      code: "BRTH"
+                      display: "Birth certificate"
+              - linkId: "parentalApplicationSupplementaryDetails_isCurrentAddressConfirmed"
+                text: "Is current address confirmed?"
+                answer:
+                  - valueBoolean: true
+              - linkId: "parentalApplicationSupplementaryDetails_liveAtSameAddress"
+                text: "Do adult and child live at the same address?"
+                answer:
+                  - valueBoolean: true
+          - linkId: "patient"
+            text: "Patient details"
+            item:
+              - linkId: "patient_identifier"
+                text: "NHS number"
+                answer:
+                  - valueString: "9000000002"
+              - linkId: "patient_name"
+                text: "Name"
+                item:
+                  - linkId: "patient_name_first"
+                    text: "First name"
+                    answer:
+                      - valueString: "Timothy"
+                  - linkId: "patient_name_family"
+                    text: "Last name"
+                    answer:
+                      - valueString: "Tenenbaum"
+              - linkId: "patient_birthDate"
+                text: "Date of birth"
+                answer:
+                  - valueDate: "2020-10-22"
+          - linkId: "requestedAccess"
+            text: "Requested access"
+            item:
+              - linkId: "requestedAccess_accessLevel"
+                text: "Requested access level"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "APPT"
+                      display: "Appointment Booking"
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "CNTCT"
+                      display: "Contacting Surgery"
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "RECRD"
+                      display: "Medical Records Access"
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "TEST"
+                      display: "Test Results"
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "VACC"
+                      display: "Vaccination Records"
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "PRESCR"
+                      display: "Repeat Prescription Requests"
+              - linkId: "requestedAccess_accessLevelMoreinfo"
+                text: "Requested access level - further information"
+                answer:
+                  - valueString: "My child cannot access their own record"
+              - linkId: "requestedAccess_reasonsForAccess"
+                text: "Reason for access"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
+                      code: "PRAC"
+                      display: "Practical Reasons"
+
+    QuestionnaireResponseAdultToAdultWithoutCapacityRequest:
+      summary: Adult > Adult (without capacity) access request
+      description: |
+        Example proxy access request from an adult (Danny) with NHS number `9876543210` requesting access to act on behalf of an elderly parent (Florence) without capacity wth NHS number `9000000008`. 
+        
+        Significant details to point out:
+
+        - `source` should be the NHS number of the proxy completing the form - this should correlate with the Identity token in the request
+        - `subject` should be the NHS Number of the patient to which the application relates (the parent without capacity in this case)
+        - `patient` demographics are present in the request as a result of being provided by the applicant
+      value: 
+        resourceType: QuestionnaireResponse        
+        status: "completed"
+        authored: "2024-07-15T09:43:03.280Z"
+        source:
+          identifier:
+            system: "https://fhir.nhs.uk/Id/nhs-number"
+            value: "9876543210"
+        subject:
+          identifier:
+            system: "https://fhir.nhs.uk/Id/nhs-number"
+            value: "9000000008"
+        questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
+        item:
+          - linkId: "relatedPerson"
+            text: "Proxy details"
+            item:
+              - linkId: "relatedPerson_identifier"
+                text: "NHS number"
+                answer:
+                  - valueString: "9876543210"
+              - linkId: "relatedPerson_basisForAccess"
+                text: "Basis for Access"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/STU3/CodeSystem/RARecord-ProxyRole-1"
+                      code: "002"
+                      display: "Best interest decision made on behalf of the patient (Mental Capacity Act 2005)"
+              - linkId: "relatedPerson_relationship"
+                text: "Relationship"
+                answer:
+                  - valueCoding:
+                      system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                      code: "CHILD"
+                      display: "Child"
+          - linkId: "patient"
+            text: "Patient details"
+            item:
+              - linkId: "patient_identifier"
+                text: "NHS number"
+                answer:
+                  - valueString: "9000000008"
+              - linkId: "patient_name"
+                text: "Name"
+                item:
+                  - linkId: "patient_name_first"
+                    text: "First name"
+                    answer:
+                      - valueString: "Florence"
+                  - linkId: "patient_name_family"
+                    text: "Last name"
+                    answer:
+                      - valueString: "Smith"
+              - linkId: "patient_birthDate"
+                text: "Date of birth"
+                answer:
+                  - valueDate: "1935-01-02"
+          - linkId: "requestedAccess"
+            text: "Requested access"
+            item:
+              - linkId: "requestedAccess_accessLevel"
+                text: "Requested access level"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "APPT"
+                      display: "Appointment Booking"
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "VACC"
+                      display: "Vaccination Records"
+              - linkId: "requestedAccess_reasonsForAccess"
+                text: "Reason for access"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
+                      code: "TECH"
+                      display: "Technical Barriers"
+
+    QuestionnaireResponseAdultToAdultWithCapacityRequest:
+      summary: Adult > Adult (with capacity) access request
+      description: |
+        Example proxy access request from an adult (Tom) with NHS number `9000000005` requesting access to act on behalf of his wife (Jill) with NHS number `9000000006`. 
+        
+        Significant details to point out:
+
+        - `source` should be the NHS number of the proxy completing the form - this should correlate with the Identity token in the request
+        - `subject` should be the NHS Number of the patient to which the application relates        
+        - `patient` demographics are present in the request as a result of being provided by the applicant
+      value: 
+        resourceType: QuestionnaireResponse        
+        status: "completed"
+        authored: "2024-07-15T09:43:03.280Z"
+        source:
+          identifier:
+            system: "https://fhir.nhs.uk/Id/nhs-number"
+            value: "9000000005"
+        subject:
+          identifier:
+            system: "https://fhir.nhs.uk/Id/nhs-number"
+            value: "9000000006"
+        questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
+        item:
+          - linkId: "relatedPerson"
+            text: "Proxy details"
+            item:
+              - linkId: "relatedPerson_identifier"
+                text: "NHS number"
+                answer:
+                  - valueString: "9000000005"
+              - linkId: "relatedPerson_basisForAccess"
+                text: "Basis for Access"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole"
+                      code: "Personal"
+                      display: "Personal relationship with the patient"
+              - linkId: "relatedPerson_relationship"
+                text: "Relationship"
+                answer:
+                  - valueCoding:
+                      system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                      code: "SPS"
+                      display: "Spouse"
+          - linkId: "patient"
+            text: "Patient details"
+            item:
+              - linkId: "patient_identifier"
+                text: "NHS number"
+                answer:
+                  - valueString: "9000000006"
+              - linkId: "patient_name"
+                text: "Name"
+                item:
+                  - linkId: "patient_name_first"
+                    text: "First name"
+                    answer:
+                      - valueString: "Jill"
+                  - linkId: "patient_name_family"
+                    text: "Last name"
+                    answer:
+                      - valueString: "Jones"
+              - linkId: "patient_birthDate"
+                text: "Date of birth"
+                answer:
+                  - valueDate: "1965-01-01"
+          - linkId: "requestedAccess"
+            text: "Requested access"
+            item:
+              - linkId: "requestedAccess_accessLevel"
+                text: "Requested access level"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "APPT"
+                      display: "Appointment Booking"
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "VACC"
+                      display: "Vaccination Records"
+              - linkId: "requestedAccess_reasonsForAccess"
+                text: "Reason for access"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
+                      code: "PRAC"
+                      display: "Practical Reasons"
+
+    QuestionnaireResponseAdultNominatesAdultRequest:
+      summary: Adult nominates Adult access request
+      description: |
+        Example proxy access request from an adult (Jill) with NHS number `9000000006` nominating her husband (Tom) with NHS number `9000000005` to act on her behalf. 
+        
+        Significant things to point out:
+
+        - `source` should be the NHS number of the patient completing the form - this should correlate with the Identity token in the request
+        - `subject` should be the NHS Number of the patient to which the application relates
+        - `relatedPerson` demographics are present in the request as a result of being provided by the applicant
+      value: 
+        resourceType: QuestionnaireResponse        
+        status: "completed"
+        authored: "2024-07-15T09:43:03.280Z"
+        source:
+          identifier:
+            system: "https://fhir.nhs.uk/Id/nhs-number"
+            value: "9000000006"
+        subject:
+          identifier:
+            system: "https://fhir.nhs.uk/Id/nhs-number"
+            value: "9000000006"
+        questionnaire: "https://api.service.nhs.uk/validated-relationships/FHIR/R4/Questionnaire/01dc6813-3421-4d14-948d-a4888241add1"
+        item:
+          - linkId: "relatedPerson"
+            text: "Proxy details"
+            item:
+              - linkId: "relatedPerson_identifier"
+                text: "NHS number"
+                answer:
+                  - valueString: "9000000005"
+              - linkId: "relatedPerson_name"
+                text: "Name"
+                item:
+                  - linkId: "relatedPerson_name_first"
+                    text: "First name"
+                    answer:
+                      - valueString: "Tom"
+                  - linkId: "relatedPerson_name_family"
+                    text: "Last name"
+                    answer:
+                      - valueString: "Jones"
+              - linkId: "relatedPerson_birthDate"
+                text: "Date of birth"
+                answer:
+                  - valueDate: "1970-07-12"
+              - linkId: "relatedPerson_basisForAccess"
+                text: "Basis for Access"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole"
+                      code: "Personal"
+                      display: "Personal relationship with the patient"
+              - linkId: "relatedPerson_relationship"
+                text: "Relationship"
+                answer:
+                  - valueCoding:
+                      system: "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+                      code: "SPS"
+                      display: "Spouse"
+          - linkId: "patient"
+            text: "Patient details"
+            item:
+              - linkId: "patient_identifier"
+                text: "NHS number"
+                answer:
+                  - valueString: "9000000006"
+          - linkId: "requestedAccess"
+            text: "Requested access"
+            item:
+              - linkId: "requestedAccess_accessLevel"
+                text: "Requested access level"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "APPT"
+                      display: "Appointment Booking"
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-RequestedAccess"
+                      code: "VACC"
+                      display: "Vaccination Records"
+              - linkId: "requestedAccess_reasonsForAccess"
+                text: "Reason for access"
+                answer:
+                  - valueCoding:
+                      system: "https://fhir.nhs.uk/CodeSystem/Proxy-Placeholder-ReasonForAccess"
+                      code: "PRAC"
+                      display: "Practical Reasons"
+
     ConsentMotherChildBundle:
       summary: Bundle containing a single active proxy relationship for a birth mother & child
       value:


### PR DESCRIPTION
## Ticket Link

<!-- Add the Jira ticket link here -->
https://nhsd-jira.digital.nhs.uk/browse/NPA-3659

## Description/Change Summary
These changes to the OAS relate to the example requests & responses. The primary objective being to remove inline examples against a given resource (which have no context in which they are being used), and replace them with completive examples. By doing so, the request/response payloads can be specific to a given scenario and therefore help integration partners understand the nuances of a given API endpoint and its behaviour.

I've also pulled out the examples into discreet files to improve readability and make maintenance easier. This gives us the future possibility of sharing examples between the OAS and the canned data that is returned by the sandbox application.

# How to test?
No behaviour has been implemented as part of this change. Changes best reviewed in a swagger editor in addition to the raw changes

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
