### PR TITLE
NPA-3877 Update Sandbox CORS on error response

### DIFF
--- a/proxies/sandbox/apiproxy/policies/RaiseFault.DefaultError.xml
+++ b/proxies/sandbox/apiproxy/policies/RaiseFault.DefaultError.xml
@@ -9,11 +9,16 @@
 -->
 <RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.DefaultError">
     <DisplayName>RaiseFault.DefaultError</DisplayName>
+
     <Properties/>
     <FaultResponse>
         <Set>
             <Headers>
               <Header name="Content-Type">application/fhir+json</Header>
+              <Header name="Access-Control-Allow-Origin">{request.header.origin}</Header>
+              <Header name="Access-Control-Allow-Headers">origin, x-requested-with, accept, content-type, nhsd-session-urid, authorization, x-correlation-id, x-request-id</Header>
+              <Header name="Access-Control-Max-Age">3628800</Header>
+              <Header name="Access-Control-Allow-Methods">GET, PUT, POST, DELETE</Header>
             </Headers>
         </Set>
     </FaultResponse>


### PR DESCRIPTION
## Pull Request Checklist

## Ticket Link

<!-- Add the Jira ticket link here -->
https://nhsd-jira.digital.nhs.uk/browse/NPA-3877

## Description/Change Summary

<!-- Describe the changes made in this PR -->

-  Added CORs headers back to response when sandbox simulates an error
- API Response from internal-dev sandbox
```
* Request completely sent off
< HTTP/1.1 400 BAD REQUEST
< Date: Thu, 31 Oct 2024 12:04:35 GMT
< Content-Type: application/fhir+json
< Content-Length: 361
< Connection: keep-alive
< Server: gunicorn
< Access-Control-Allow-Origin:
< Access-Control-Allow-Headers: origin, x-requested-with, accept, content-type, nhsd-session-urid, authorization, x-correlation-id, x-request-id
< Access-Control-Max-Age: 3628800
< Access-Control-Allow-Methods: GET, PUT, POST, DELETE
< Strict-Transport-Security: max-age=31536000; includeSubDomains
< X-Correlation-ID: 11c46f5f-cdef-4865-94b2-0ee0edcc26da
< X-Request-ID: 60e0b220-8136-4ca5-ae46-1d97ef59d068
<
{"issue":[{"code":"invalid","details":{"coding":[{"code":"INVALID_IDENTIFIER_VALUE","display":"Provided value is invalid","system":"https://fhir.nhs.uk/R4/CodeSystem/ValidatedRelationships-ErrorOrWarningCode","version":"1"}]},"diagnostics":"Not a valid NHS Number provided for the 'identifier' parameter","severity":"error"}],"resourceType":"OperationOutcome"}
* Connection #0 to host internal-dev-sandbox.api.service.nhs.uk left intact
```
- Unable to be tested using API catalogue before merge, will be checked by @ClarksonAdam and I after merge
