### PR TITLE
NPA-3545 Update Postman Collection with X-headers

### DIFF
--- a/postman/Validate Relationship Service Sandbox.postman_collection.json
+++ b/postman/Validate Relationship Service Sandbox.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "85ee4695-8528-4e6e-82a6-29c4bea26a6d",
+		"_postman_id": "f29c97c0-1137-4f8e-966f-1affba55fef1",
 		"name": "Validate Relationship Service Sandbox",
 		"description": "Example usage of the Validate Relationship Service (VRS) sandbox.\n\nFull specification is available at [https://digital.nhs.uk/developer/api-catalogue/validated-relationship-service](https://digital.nhs.uk/developer/api-catalogue/validated-relationship-service)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -14,7 +14,18 @@
 					"name": "Relationship information",
 					"request": {
 						"method": "GET",
-						"header": [],
+						"header": [
+							{
+								"key": "X-Request-ID",
+								"value": "d967f4c9-8e83-4930-97ab-ae4e122d8ca5",
+								"type": "text"
+							},
+							{
+								"key": "X-Correlation-ID",
+								"value": "8717c840-c222-4f84-a880-45bc129f8382",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "{{api_base_url}}/RelatedPerson?patient:identifier=9000000009&identifier=9000000017",
 							"host": [
@@ -42,7 +53,18 @@
 					"name": "Relationship with additional information",
 					"request": {
 						"method": "GET",
-						"header": [],
+						"header": [
+							{
+								"key": "X-Request-ID",
+								"value": "d967f4c9-8e83-4930-97ab-ae4e122d8ca5",
+								"type": "text"
+							},
+							{
+								"key": "X-Correlation-ID",
+								"value": "8717c840-c222-4f84-a880-45bc129f8382",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "{{api_base_url}}/RelatedPerson?patient:identifier=9000000025&identifier=9000000017&_include=RelatedPerson:patient",
 							"host": [
@@ -80,7 +102,18 @@
 					"name": "Relationship list",
 					"request": {
 						"method": "GET",
-						"header": [],
+						"header": [
+							{
+								"key": "X-Request-ID",
+								"value": "d967f4c9-8e83-4930-97ab-ae4e122d8ca5",
+								"type": "text"
+							},
+							{
+								"key": "X-Correlation-ID",
+								"value": "8717c840-c222-4f84-a880-45bc129f8382",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "{{api_base_url}}/RelatedPerson?identifier=9000000017",
 							"host": [
@@ -104,7 +137,18 @@
 					"name": "Relationship list with additional information",
 					"request": {
 						"method": "GET",
-						"header": [],
+						"header": [
+							{
+								"key": "X-Request-ID",
+								"value": "d967f4c9-8e83-4930-97ab-ae4e122d8ca5",
+								"type": "text"
+							},
+							{
+								"key": "X-Correlation-ID",
+								"value": "8717c840-c222-4f84-a880-45bc129f8382",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "{{api_base_url}}/RelatedPerson?identifier=9000000017&_include=RelatedPerson:patient",
 							"host": [
@@ -132,7 +176,18 @@
 					"name": "Invalid NHS number",
 					"request": {
 						"method": "GET",
-						"header": [],
+						"header": [
+							{
+								"key": "X-Request-ID",
+								"value": "d967f4c9-8e83-4930-97ab-ae4e122d8ca5",
+								"type": "text"
+							},
+							{
+								"key": "X-Correlation-ID",
+								"value": "8717c840-c222-4f84-a880-45bc129f8382",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "{{api_base_url}}/RelatedPerson?identifier=12345678900",
 							"host": [
@@ -156,7 +211,18 @@
 					"name": "No matching record",
 					"request": {
 						"method": "GET",
-						"header": [],
+						"header": [
+							{
+								"key": "X-Request-ID",
+								"value": "d967f4c9-8e83-4930-97ab-ae4e122d8ca5",
+								"type": "text"
+							},
+							{
+								"key": "X-Correlation-ID",
+								"value": "8717c840-c222-4f84-a880-45bc129f8382",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "{{api_base_url}}/RelatedPerson?identifier=9000000041",
 							"host": [
@@ -180,7 +246,18 @@
 					"name": "No relationships found",
 					"request": {
 						"method": "GET",
-						"header": [],
+						"header": [
+							{
+								"key": "X-Request-ID",
+								"value": "d967f4c9-8e83-4930-97ab-ae4e122d8ca5",
+								"type": "text"
+							},
+							{
+								"key": "X-Correlation-ID",
+								"value": "8717c840-c222-4f84-a880-45bc129f8382",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "{{api_base_url}}/RelatedPerson?identifier=9000000033",
 							"host": [
@@ -213,7 +290,18 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/fhir+json"
+								"value": "application/fhir+json",
+								"type": "text"
+							},
+							{
+								"key": "X-Request-ID",
+								"value": "d967f4c9-8e83-4930-97ab-ae4e122d8ca5",
+								"type": "text"
+							},
+							{
+								"key": "X-Correlation-ID",
+								"value": "8717c840-c222-4f84-a880-45bc129f8382",
+								"type": "text"
 							}
 						],
 						"body": {

--- a/specification/validated-relationships-service-api.yaml
+++ b/specification/validated-relationships-service-api.yaml
@@ -124,7 +124,7 @@ info:
     * is open access, so does not allow you to test authorisation
 
 
-    [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/34042403-2aa5ee88-38a4-4c42-b563-c2d76577d2f2?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D34042403-2aa5ee88-38a4-4c42-b563-c2d76577d2f2%26entityType%3Dcollection%26workspaceId%3D19103c6d-7e94-482c-bcc6-07d84bafd9e5)
+    [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/34042403-f29c97c0-1137-4f8e-966f-1affba55fef1?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D34042403-f29c97c0-1137-4f8e-966f-1affba55fef1%26entityType%3Dcollection%26workspaceId%3D19a38606-58f9-4c03-ad4b-dec73a45856d)
 
     ### Integration testing
 


### PR DESCRIPTION
## Pull Request Checklist

## Ticket Link

<!-- Add the Jira ticket link here -->
https://nhsd-jira.digital.nhs.uk/browse/NPA-3545

## Description/Change Summary

<!-- Describe the changes made in this PR -->

- X-Request-ID and X-Correlation-ID has been applied to all Postman requests (Related Person + QuestionnaireResponse)
- Exported updated collection to repository
- Updated link to new public collection
- Tested the updated collection and still works with Sandbox
<img width="1105" alt="image" src="https://github.com/user-attachments/assets/b8f05290-5729-4085-a05b-10525bd74148">
