### PR TITLE
NPA-4104 Document RelatedPerson Relationship Direction

### DIFF
--- a/specification/validated-relationships-service-api.yaml
+++ b/specification/validated-relationships-service-api.yaml
@@ -650,7 +650,6 @@ components:
                                   enum: ['Parent', 'Personal relationship with the patient', 'Best interest decision made on behalf of the patient (Mental Capacity Act 2005)']
 
               - type: object
-                description: The relationship of the RelatedPerson to the Patient. For example, if the Patient is a child, and the RelatedPerson is the mother, the relationship would be PRN (parent).
                 required:
                   - linkId
                   - text
@@ -663,6 +662,7 @@ components:
                     type: string
                   answer:
                     type: array
+                    description: The relationship of the RelatedPerson to the Patient. For example, if the Patient is a child, and the RelatedPerson is the mother, the relationship would be PRN (parent).
                     minItems: 1
                     maxItems: 1
                     items:

--- a/specification/validated-relationships-service-api.yaml
+++ b/specification/validated-relationships-service-api.yaml
@@ -650,6 +650,7 @@ components:
                                   enum: ['Parent', 'Personal relationship with the patient', 'Best interest decision made on behalf of the patient (Mental Capacity Act 2005)']
 
               - type: object
+                description: The relationship of the RelatedPerson to the Patient. For example, if the Patient is a child, and the RelatedPerson is the mother, the relationship would be PRN (parent).
                 required:
                   - linkId
                   - text

--- a/specification/validated-relationships-service-api.yaml
+++ b/specification/validated-relationships-service-api.yaml
@@ -662,7 +662,7 @@ components:
                     type: string
                   answer:
                     type: array
-                    description: The relationship of the RelatedPerson to the Patient. For example, if the Patient is a child, and the RelatedPerson is the mother, the relationship would be PRN (parent).
+                    description: The directionality of the relationship is from the RelatedPerson (proxy) to the Patient. For example, if the Patient is a child, and the RelatedPerson is the mother, the relationship would be PRN (parent). Crucially, the relationship type is defined by the role that the proxy plays in the relationship.
                     minItems: 1
                     maxItems: 1
                     items:


### PR DESCRIPTION
## Pull Request Checklist

## Ticket Link

<!-- Add the Jira ticket link here -->
https://nhsd-jira.digital.nhs.uk/browse/NPA-4104

## Description/Change Summary

<!-- Describe the changes made in this PR -->

- Add description to relatedPerson_relationship to document the direction of the relationship `The directionality of the relationship is from the RelatedPerson (proxy) to the Patient. For example, if the Patient is a child, and the RelatedPerson is the mother, the relationship would be PRN (parent). Crucially, the relationship type is defined by the role that the proxy plays in the relationship.`