### PR TITLE
NPA-4599: Update python scripts to check path suffix contains rather than equals specific string to account for path parameters

### DIFF
--- a/proxies/live/apiproxy/resources/py/check-app-enabled-endpoint.py
+++ b/proxies/live/apiproxy/resources/py/check-app-enabled-endpoint.py
@@ -6,6 +6,7 @@ blocked_resources = [
     ("/fhir/r4/questionnaireresponse", "post"),
 ]
 
+auth_forbidden = False
 for blocked_resources in blocked_resources:
     if blocked_resources[0] in path_suffix and blocked_resources[1] == request_verb:
         auth_forbidden = True

--- a/proxies/live/apiproxy/resources/py/check-app-enabled-endpoint.py
+++ b/proxies/live/apiproxy/resources/py/check-app-enabled-endpoint.py
@@ -1,12 +1,13 @@
 path_suffix = flow.getVariable("proxy.pathsuffix").lower()
 request_verb = flow.getVariable("request.verb").lower()
 
-requested_endpoint = (path_suffix, request_verb)
-
-
-auth_forbidden = requested_endpoint in [
+blocked_resources = [
     ("/fhir/r4/relatedperson", "get"),
     ("/fhir/r4/questionnaireresponse", "post"),
 ]
+
+for blocked_resources in blocked_resources:
+    if blocked_resources[0] in path_suffix and blocked_resources[1] == request_verb:
+        auth_forbidden = True
 
 flow.setVariable("app_auth_forbidden", auth_forbidden)

--- a/proxies/live/apiproxy/resources/py/check-user-enabled-endpoint.py
+++ b/proxies/live/apiproxy/resources/py/check-user-enabled-endpoint.py
@@ -2,8 +2,6 @@ auth_level = flow.getVariable("accesstoken.auth_level").lower()
 path_suffix = flow.getVariable("proxy.pathsuffix").lower()
 request_verb = flow.getVariable("request.verb").lower()
 
-requested_resource = (path_suffix, request_verb)
-
 if auth_level == "p9":
     blocked_resources = [("/fhir/r4/consent", "post"), ("/fhir/r4/consent", "patch")]
 elif auth_level == "all3":
@@ -11,6 +9,8 @@ elif auth_level == "all3":
 else:
     blocked_resources = []
 
-auth_forbidden = requested_resource in blocked_resources
+for blocked_resources in blocked_resources:
+    if blocked_resources[0] in path_suffix and blocked_resources[1] == request_verb:
+        auth_forbidden = True
 
 flow.setVariable("user_auth_forbidden", auth_forbidden)

--- a/proxies/live/apiproxy/resources/py/check-user-enabled-endpoint.py
+++ b/proxies/live/apiproxy/resources/py/check-user-enabled-endpoint.py
@@ -9,6 +9,7 @@ elif auth_level == "all3":
 else:
     blocked_resources = []
 
+auth_forbidden = False
 for blocked_resources in blocked_resources:
     if blocked_resources[0] in path_suffix and blocked_resources[1] == request_verb:
         auth_forbidden = True


### PR DESCRIPTION
# Pull Request

## Ticket Link


https://nhsd-jira.digital.nhs.uk/browse/NPA-4599

## Description/Change Summary

- Updated the python scripts checking if a user or app is authorized to use a particular endpoint to compare the path suffix using contains rather than equals as currently it does not account for path parameters. E.g /FHIR/R4/Consent/c6f48e4d was not being caught in the blocked response for a p9 user.

## How to test?
- Deploy changes to dev and ensure none of the testing suite is failing
- Ensure a user authenticated with p9 access can call the patch Consent endpoint

<!--
Stages to complete before opening the Pull Request:
- PR title should be formatted in the following structure `NPA-XXXXX: title abc`
- Added yourself/others as Assignees
-->

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

-   [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
-   [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
-   [ ] I have ensured the changelog has been updated by the submitter, if necessary.

## Post-merge

After merging and deploying changes to the sandbox, Postman collection or spec examples please run the `Run Postman collection` workflow.

This will run the tests within the collection to check that the sandbox is working as expected once deployed.
