### PR TITLE
NPA-4699: Align blocked resources for different auths with confluence table

### DIFF
--- a/proxies/live/apiproxy/resources/py/check-app-enabled-endpoint.py
+++ b/proxies/live/apiproxy/resources/py/check-app-enabled-endpoint.py
@@ -1,18 +1,23 @@
 path_suffix = flow.getVariable("proxy.pathsuffix").lower()
 request_verb = flow.getVariable("request.verb").lower()
 
-blocked_resources = [
-    ("/fhir/r4/relatedperson", "get"),
-    ("/fhir/r4/questionnaire", "get"),
-    ("/fhir/r4/questionnaireresponse", "post"),
-    ("/fhir/r4/questionnaireresponse", "get"),
-    ("/fhir/r4/consent", "post"),
-    ("/fhir/r4/consent", "patch"),
-]
-
 auth_forbidden = False
-for blocked_resources in blocked_resources:
-    if blocked_resources[0] in path_suffix and blocked_resources[1] == request_verb:
-        auth_forbidden = True
+if request_verb == "patch":
+    # Check blocked endpoint is within path suffix i.e. ignore path parameters
+    blocked_resources = ["/fhir/r4/consent"]
+    for blocked_resource in blocked_resources:
+        if blocked_resource in path_suffix:
+            auth_forbidden = True
+else:
+    # Check blocked endpoint is equal to path suffix
+    requested_resource = (path_suffix, request_verb)
+    blocked_resources = [
+        ("/fhir/r4/relatedperson", "get"),
+        ("/fhir/r4/questionnaire", "get"),
+        ("/fhir/r4/questionnaireresponse", "post"),
+        ("/fhir/r4/questionnaireresponse", "get"),
+        ("/fhir/r4/consent", "post"),
+    ]
+    auth_forbidden = requested_resource in blocked_resources
 
 flow.setVariable("app_auth_forbidden", auth_forbidden)

--- a/proxies/live/apiproxy/resources/py/check-user-enabled-endpoint.py
+++ b/proxies/live/apiproxy/resources/py/check-user-enabled-endpoint.py
@@ -2,6 +2,8 @@ auth_level = flow.getVariable("accesstoken.auth_level").lower()
 path_suffix = flow.getVariable("proxy.pathsuffix").lower()
 request_verb = flow.getVariable("request.verb").lower()
 
+requested_resource = (path_suffix, request_verb)
+
 if auth_level == "p9":
     blocked_resources = [
         ("/fhir/r4/questionnaire", "get"),
@@ -12,9 +14,6 @@ elif auth_level == "all3":
 else:
     blocked_resources = []
 
-auth_forbidden = False
-for blocked_resources in blocked_resources:
-    if blocked_resources[0] in path_suffix and blocked_resources[1] == request_verb:
-        auth_forbidden = True
+auth_forbidden = requested_resource in blocked_resources
 
 flow.setVariable("user_auth_forbidden", auth_forbidden)


### PR DESCRIPTION
# Pull Request


## Ticket Link

https://nhsd-jira.digital.nhs.uk/browse/NPA-4699

## Description/Change Summary

- Align different auth blocked endpoints with confluence table found [here](https://nhsd-confluence.digital.nhs.uk/display/NPA/Service+overview+-+NPA#ServiceoverviewNPA-Security)


## How to test?

- Run api test suite in proxy-validated-relationships-api service

<!--
Stages to complete before opening the Pull Request:
- PR title should be formatted in the following structure `NPA-XXXXX: title abc`
- Added yourself/others as Assignees
-->

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

-   [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
-   [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
-   [ ] I have ensured the changelog has been updated by the submitter, if necessary.

## Post-merge

After merging and deploying changes to the sandbox, Postman collection or spec examples please run the `Run Postman collection` workflow.

This will run the tests within the collection to check that the sandbox is working as expected once deployed.
